### PR TITLE
Use index 0 of concentration arrays

### DIFF
--- a/src/MicroscaleFlat.cs
+++ b/src/MicroscaleFlat.cs
@@ -27,6 +27,7 @@ namespace GRAL_2001
             Console.WriteLine("FLOW FIELD COMPUTATION WITHOUT TOPOGRAPHY");
 
             Program.KADVMAX = 1;
+            Program.SubDomainRefPos = new IntPoint(1, 1);
             int inumm = Program.MetProfileNumb;
 
             //set wind-speed components equal to zero

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -118,7 +118,7 @@ namespace GRAL_2001
             //Lowest grid level of the prognostic flow field model grid
             HOKART[0] = 0;
 
-            //read main GRAL domain file "GRAL.geb" and check if the file "UseOrigTopography.txt" exists
+            //read main GRAL domain file "GRAL.geb" and check if the file "UseOrigTopography.txt" exists -> needed to read In.Dat!
             ReaderClass.ReadGRALGeb();
 
             //optional: read GRAMM file ggeom.asc
@@ -243,7 +243,7 @@ namespace GRAL_2001
             {
                 try
                 {
-                    Info = "  Slice height above ground [m]: " + HorSlices[i + 1].ToString();
+                    Info = "  Slice height above ground [m]: " + HorSlices[i].ToString();
                     Console.WriteLine(Info);
                 }
                 catch

--- a/src/ProgramFunctions.cs
+++ b/src/ProgramFunctions.cs
@@ -124,11 +124,11 @@ namespace GRAL_2001
                 if ((HOKART[i] >= (AHMAX - AHMIN + 300)) && (HOKART[i] >= 800))
                 {
                     nkk = i;
+                    ModelTopHeight = HOKART[i] + AHMIN;
                     break;
                 }
             }
-
-            ModelTopHeight = HOKART[NKK] + AHMIN;
+             
             nkk = Math.Min(nkk, VerticalCellMaxBound - 2);
             return nkk;
         }
@@ -365,7 +365,7 @@ namespace GRAL_2001
             NX2 = NX + 2;
             NY2 = NY + 2;
             NZ2 = NZ + 2;
-            Conz3d = CreateArray<float[][][]>(NXL + 2, () => CreateArray<float[][]>(NYL + 2, () => CreateArray<float[]>(NS + 1, () => new float[Program.SourceGroups.Count + 1])));
+            Conz3d = CreateArray<float[][][]>(NXL + 2, () => CreateArray<float[][]>(NYL + 2, () => CreateArray<float[]>(NS, () => new float[Program.SourceGroups.Count + 1])));
             XKO = new double[NX2];
             YKO = new double[NY2];
             ZKO = new double[NZ2];
@@ -379,7 +379,7 @@ namespace GRAL_2001
             WWIN = CreateArray<float[][]>(NX1, () => CreateArray<float[]>(NY1, () => new float[NZ1]));
             TKE = CreateArray<float[][]>(NX1, () => CreateArray<float[]>(NY1, () => new float[NZ1]));
             DISS = CreateArray<float[][]>(NX1, () => CreateArray<float[]>(NY1, () => new float[NZ1]));
-            HorSlices = new float[NS + 1];
+            HorSlices = new float[NS];
             Z0Gramm = CreateArray<float[]>(NX1, () => new float[NY1]);
             Ustern = CreateArray<float[]>(NX1, () => new float[NY1]);
             Ob = CreateArray<float[]>(NX1, () => new float[NY1]);
@@ -389,10 +389,10 @@ namespace GRAL_2001
             //create additional concentration arrays for calculating concentration gradients used for odour-hour modelling
             if (Odour == true)
             {
-                Conz3dp = CreateArray<float[][][]>(NXL + 2, () => CreateArray<float[][]>(NYL + 2, () => CreateArray<float[]>(NS + 1, () => new float[Program.SourceGroups.Count + 1])));
-                Conz3dm = CreateArray<float[][][]>(NXL + 2, () => CreateArray<float[][]>(NYL + 2, () => CreateArray<float[]>(NS + 1, () => new float[Program.SourceGroups.Count + 1])));
-                Q_cv0 = CreateArray<float[]>(NS + 1, () => new float[Program.SourceGroups.Count + 1]);
-                DisConcVar = CreateArray<float[]>(NS + 1, () => new float[Program.SourceGroups.Count + 1]);
+                Conz3dp = CreateArray<float[][][]>(NXL + 2, () => CreateArray<float[][]>(NYL + 2, () => CreateArray<float[]>(NS, () => new float[Program.SourceGroups.Count + 1])));
+                Conz3dm = CreateArray<float[][][]>(NXL + 2, () => CreateArray<float[][]>(NYL + 2, () => CreateArray<float[]>(NS, () => new float[Program.SourceGroups.Count + 1])));
+                Q_cv0 = CreateArray<float[]>(NS, () => new float[Program.SourceGroups.Count + 1]);
+                DisConcVar = CreateArray<float[]>(NS, () => new float[Program.SourceGroups.Count + 1]);
             }
 
             //array for computing deposition
@@ -944,11 +944,11 @@ namespace GRAL_2001
                 double x0 = i * Program.GralDx;
                 double xmax = x0 + Program.GralDx;
 
-                Span<double> VolumeReduction = stackalloc double[Program.NS + 1];
-                Span<float> HMin = stackalloc float[Program.NS + 1];
-                Span<float> HMax = stackalloc float[Program.NS + 1];
+                Span<double> VolumeReduction = stackalloc double[Program.NS];
+                Span<float> HMin = stackalloc float[Program.NS];
+                Span<float> HMax = stackalloc float[Program.NS];
 
-                for (int k = 1; k < HMin.Length; k++)
+                for (int k = 0; k < HMin.Length; k++)
                 {
                     HMin[k] = Program.HorSlices[k] - Program.GralDz * 0.5F + DeltaH;
                     HMax[k] = Program.HorSlices[k] + Program.GralDz * 0.5F + DeltaH;
@@ -973,7 +973,7 @@ namespace GRAL_2001
                                 {
                                     float buidingheight = Program.BUI_HEIGHT[IndexI][IndexJ];
                                     // loop over all slices
-                                    for (int k = 1; k < HMin.Length; k++)
+                                    for (int k = 0; k < HMin.Length; k++)
                                     {
                                         if (buidingheight > HMin[k])
                                         {
@@ -988,7 +988,7 @@ namespace GRAL_2001
                     int iko = i + 1;
                     int jko = j + 1;
                     // Correction of the concentration
-                    for (int k = 1; k < HMin.Length; k++)
+                    for (int k = 0; k < HMin.Length; k++)
                     {
                         if (VolumeReduction[k] > 0)
                         {
@@ -1044,10 +1044,10 @@ namespace GRAL_2001
             // loop over all concentration cells
             Parallel.For(0, Program.NXL, Program.pOptions, i =>
             {
-                Span<float> HMin = stackalloc float[Program.NS + 1];
-                Span<float> HMax = stackalloc float[Program.NS + 1];
+                Span<float> HMin = stackalloc float[Program.NS];
+                Span<float> HMax = stackalloc float[Program.NS];
 
-                for (int k = 1; k < HMin.Length; k++)
+                for (int k = 0; k < HMin.Length; k++)
                 {
                     HMin[k] = Program.HorSlices[k] - Program.GralDz * 0.5F + DeltaH;
                     HMax[k] = Program.HorSlices[k] + Program.GralDz * 0.5F + DeltaH - 0.2F;
@@ -1058,7 +1058,7 @@ namespace GRAL_2001
                     float buidingheight = Program.BUI_HEIGHT[i][j];
 
                     // loop over all slices
-                    for (int k = 1; k < HMin.Length; k++)
+                    for (int k = 0; k < HMin.Length; k++)
                     {
                         if (buidingheight > HMin[k] && buidingheight < HMax[k])
                         {

--- a/src/ReadGeometryAndDomains.cs
+++ b/src/ReadGeometryAndDomains.cs
@@ -137,7 +137,6 @@ namespace GRAL_2001
                                 ;
                             }
                         }
-
                         Environment.Exit(0);
                     }
 

--- a/src/ReadInDat.cs
+++ b/src/ReadInDat.cs
@@ -25,7 +25,7 @@ namespace GRAL_2001
     public partial class ProgramReaders
     {
         /// <summary>
-        ///Read the main control file in.dat
+        ///Read the main control file in.dat - Gral.geb must be read before this routine!
         /// </summary>
         public void ReadInDat()
         {
@@ -99,13 +99,13 @@ namespace GRAL_2001
 
                         _line++;
                         text = sr.ReadLine().Split(new char[] { ' ', ',', '\r', '\n', ';', '!' }, StringSplitOptions.RemoveEmptyEntries);
-                        for (int i = 0; i <= Program.NS; i++)
+                        for (int i = 0; i < Program.NS; i++)
                         {
                             try
                             {
                                 text[i] = text[i].Trim();
                                 text[i] = text[i].Replace(".", decsep);
-                                Program.HorSlices[i + 1] = Convert.ToSingle(text[i]);
+                                Program.HorSlices[i] = Convert.ToSingle(text[i]);
                             }
                             catch { }
                         }

--- a/src/Write2DConcentrations.cs
+++ b/src/Write2DConcentrations.cs
@@ -36,9 +36,9 @@ namespace GRAL_2001
                         {
                             for (int IQ = 0; IQ < Program.SourceGroups.Count; IQ++)
                             {
-                                for (int II = 1; II <= Program.NS; II++)
+                                for (int II = 0; II < Program.NS; II++)
                                 {
-                                    string fname = Program.IWET.ToString("00000") + "-" + II.ToString("0") + Program.SourceGroups[IQ].ToString("00") + ".con";
+                                    string fname = Program.IWET.ToString("00000") + "-" + (II + 1).ToString("0") + Program.SourceGroups[IQ].ToString("00") + ".con";
 
                                     if (Program.WriteASCiiResults) // aditional ASCii Output
                                     {
@@ -64,7 +64,7 @@ namespace GRAL_2001
                                     }
 
                                     // Write deposition
-                                    if (II == 1 && (Program.DepositionExist || Program.WetDeposition))
+                                    if (II == 0 && (Program.DepositionExist || Program.WetDeposition))
                                     {
                                         fname = Program.IWET.ToString("00000") + "-" + Program.SourceGroups[IQ].ToString("00") + ".dep";
                                         write_entry = archive.CreateEntry(fname);
@@ -94,9 +94,9 @@ namespace GRAL_2001
                 {
                     for (int IQ = 0; IQ < Program.SourceGroups.Count; IQ++)
                     {
-                        for (int II = 1; II <= Program.NS; II++)
+                        for (int II = 0; II < Program.NS; II++)
                         {
-                            string fname = Program.IWET.ToString("00000") + "-" + II.ToString("0") + Program.SourceGroups[IQ].ToString("00") + ".con";
+                            string fname = Program.IWET.ToString("00000") + "-" + (II + 1).ToString("0") + Program.SourceGroups[IQ].ToString("00") + ".con";
 
                             if (Program.WriteASCiiResults) // aditional ASCii Output
                             {
@@ -109,7 +109,7 @@ namespace GRAL_2001
                             }
 
                             // Write deposition
-                            if (II == 1 && (Program.DepositionExist || Program.WetDeposition))
+                            if (II == 0 && (Program.DepositionExist || Program.WetDeposition))
                             {
                                 fname = Program.IWET.ToString("00000") + "-" + Program.SourceGroups[IQ].ToString("00") + ".dep";
                                 using (BinaryWriter sw = new BinaryWriter(File.Open(fname, FileMode.Create)))
@@ -136,7 +136,7 @@ namespace GRAL_2001
 
                 for (int IQ = 0; IQ < Program.SourceGroups.Count; IQ++)
                 {
-                    for (int II = 1; II <= Program.NS; II++)
+                    for (int II = 0; II < Program.NS; II++)
                     {
                         Object thisLock = new Object();
 
@@ -285,7 +285,7 @@ namespace GRAL_2001
             //reset concentrations
             for (int iq = 0; iq < Program.SourceGroups.Count; iq++)
             {
-                for (int II = 1; II <= Program.NS; II++)
+                for (int II = 0; II < Program.NS; II++)
                 {
                     for (int i = 1; i <= Program.NXL; i++)
                     {

--- a/src/WriteLogFiles.cs
+++ b/src/WriteLogFiles.cs
@@ -66,7 +66,7 @@ namespace GRAL_2001
             {
                 try
                 {
-                    err = "    Slice height above ground [m]: " + Program.HorSlices[i + 1].ToString();
+                    err = "    Slice height above ground [m]: " + Program.HorSlices[i].ToString();
                     LogfileGralCoreWrite(err);
                 }
                 catch

--- a/src/Zeitschleife.cs
+++ b/src/Zeitschleife.cs
@@ -99,7 +99,7 @@ namespace GRAL_2001
             int IKOOAGRAL = Program.IKOOAGRAL;
             int JKOOAGRAL = Program.JKOOAGRAL;
 
-            Span<int> kko = stackalloc int[Program.NS + 1];
+            Span<int> kko = stackalloc int[Program.NS];
             double[] ReceptorConcentration = new double[Program.ReceptorNumber + 1];
             float a1 = 0.05F, a2 = 1.7F, a3 = 1.1F;
 
@@ -1771,7 +1771,7 @@ namespace GRAL_2001
                 {
                     zcoordRelative = zcoord_nteil - AHint;
                 }
-                for (int II = 1; II < kko.Length; II++)
+                for (int II = 0; II < kko.Length; II++)
                 {
                     float slice = (zcoordRelative - Program.HorSlices[II]) * dz_rez;
                     if (Math.Abs(slice) > Int16.MaxValue)
@@ -1845,7 +1845,7 @@ namespace GRAL_2001
                     }
 
                     //compute 2D - concentrations
-                    for (int II = 1; II < kko.Length; II++)
+                    for (int II = 0; II < kko.Length; II++)
                     {
                         if ((kko[II] == 0) && (reflexion_flag == 0))
                         {
@@ -1879,12 +1879,12 @@ namespace GRAL_2001
                     //ODOUR Dispersion requires the concentration fields above and below the acutal layer
                     if (Program.Odour == true)
                     {
-                        for (int II = 1; II < kko.Length; II++)
+                        for (int II = 0; II < kko.Length; II++)
                         {
                             float slice = (zcoordRelative - (Program.HorSlices[II] + Program.GralDz)) * dz_rez;
                             kko[II] = Program.ConvToInt(Math.Min(int.MaxValue, slice));
                         }
-                        for (int II = 1; II < kko.Length; II++)
+                        for (int II = 0; II < kko.Length; II++)
                         {
                             if ((kko[II] == 0) && (reflexion_flag == 0))
                             {
@@ -1896,12 +1896,12 @@ namespace GRAL_2001
                                 }
                             }
                         }
-                        for (int II = 1; II < kko.Length; II++)
+                        for (int II = 0; II < kko.Length; II++)
                         {
                             float slice = (zcoordRelative - (Program.HorSlices[II] - Program.GralDz)) * dz_rez;
                             kko[II] = Program.ConvToInt(Math.Min(int.MaxValue, slice));
                         }
-                        for (int II = 1; II < kko.Length; II++)
+                        for (int II = 0; II < kko.Length; II++)
                         {
                             if ((kko[II] == 0) && (reflexion_flag == 0))
                             {

--- a/src/Zeitschleife_nonsteadystate.cs
+++ b/src/Zeitschleife_nonsteadystate.cs
@@ -98,7 +98,7 @@ namespace GRAL_2001
             int IKOOAGRAL = Program.IKOOAGRAL;
             int JKOOAGRAL = Program.JKOOAGRAL;
 
-            Span<int> kko = stackalloc int[Program.NS + 1];
+            Span<int> kko = stackalloc int[Program.NS];
             double[] ReceptorConcentration = new double[Program.ReceptorNumber + 1];
             float a3 = 1.1F;
 
@@ -114,8 +114,8 @@ namespace GRAL_2001
             TransientConcentration trans_conz = new TransientConcentration();
 
             /*
-			 *   INITIIALIZING PARTICLE PROPERTIES -> DEPEND ON SOURCE CATEGORY
-			 */
+             *   INITIIALIZING PARTICLE PROPERTIES -> DEPEND ON SOURCE CATEGORY
+             */
             int IUstern = 1, JUstern = 1;
             float AHint = 0;
             float AHintold = 0;
@@ -274,8 +274,8 @@ namespace GRAL_2001
                     goto REMOVE_PARTICLE;
 
                 /*
-				 *   VERTICAL DIFFUSION ACCORING TO FRANZESE, 1999
-				 */
+                 *   VERTICAL DIFFUSION ACCORING TO FRANZESE, 1999
+                 */
 
                 //dissipation
                 float ObLength = Program.Ob[IUstern][JUstern];
@@ -432,8 +432,8 @@ namespace GRAL_2001
                 float cory = velyold * idt;
 
                 /*
-				 *    HORIZONTAL DIFFUSION ACCORDING TO ANFOSSI ET AL. (2006)
-				 */
+                 *    HORIZONTAL DIFFUSION ACCORDING TO ANFOSSI ET AL. (2006)
+                 */
 
                 //vertical interpolation of horizontal standard deviations of wind speed components
                 Zeitschleife.IntStandCalculate(0, IUstern, JUstern, diff_building, windge, sigmauhurly, ref U0int, ref V0int);
@@ -975,7 +975,7 @@ namespace GRAL_2001
                 {
                     zcoordRelative = zcoord_nteil - AHint;
                 }
-                for (int II = 1; II < kko.Length; II++)
+                for (int II = 0; II < kko.Length; II++)
                 {
                     float slice = (zcoordRelative - Program.HorSlices[II]) * dz_rez;
                     if (Math.Abs(slice) > Int16.MaxValue)
@@ -1048,7 +1048,7 @@ namespace GRAL_2001
                     }
 
                     //compute 2D - concentrations
-                    for (int II = 1; II < kko.Length; II++)
+                    for (int II = 0; II < kko.Length; II++)
                     {
                         if ((kko[II] == 0) && (reflexion_flag == 0))
                         {
@@ -1079,12 +1079,12 @@ namespace GRAL_2001
                     //ODOUR Dispersion requires the concentration fields above and below the acutal layer
                     if (Program.Odour == true)
                     {
-                        for (int II = 1; II < kko.Length; II++)
+                        for (int II = 0; II < kko.Length; II++)
                         {
                             float slice = (zcoordRelative - (Program.HorSlices[II] + Program.GralDz)) * dz_rez;
                             kko[II] = Program.ConvToInt(Math.Min(int.MaxValue, slice));
                         }
-                        for (int II = 1; II < kko.Length; II++)
+                        for (int II = 0; II < kko.Length; II++)
                         {
                             if ((kko[II] == 0) && (reflexion_flag == 0))
                             {
@@ -1096,12 +1096,12 @@ namespace GRAL_2001
                                 }
                             }
                         }
-                        for (int II = 1; II < kko.Length; II++)
+                        for (int II = 0; II < kko.Length; II++)
                         {
                             float slice = (zcoordRelative - (Program.HorSlices[II] - Program.GralDz)) * dz_rez;
                             kko[II] = Program.ConvToInt(Math.Min(int.MaxValue, slice));
                         }
-                        for (int II = 1; II < kko.Length; II++)
+                        for (int II = 0; II < kko.Length; II++)
                         {
                             if ((kko[II] == 0) && (reflexion_flag == 0))
                             {


### PR DESCRIPTION
Use the index 0 for concentration arrays to save memory (nx * ny * SourceGroup.count * 4Bytes)