### PR TITLE
V2404 Service Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/src/GRAL.csproj
+++ b/src/GRAL.csproj
@@ -7,14 +7,14 @@
     <Authors>Dietmar Oettl;Markus Kuntner</Authors>
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyTitle>GRAL</AssemblyTitle>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     <Optimize>true</Optimize>
-    <TieredCompilation>false</TieredCompilation>
+    <TieredCompilation>true</TieredCompilation>
     <TieredCompilationQuickJit>false</TieredCompilationQuickJit>
     <DOTNET_TC_QuickJitForLoops>false</DOTNET_TC_QuickJitForLoops>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TieredPGO>false</TieredPGO>
+    <TieredPGO>true</TieredPGO>
     <DOTNET_EnableDiagnostics>false</DOTNET_EnableDiagnostics>
     <DOTNET_ENABLE_PROFILING>false</DOTNET_ENABLE_PROFILING>
     <RetainVMGarbageCollection>false</RetainVMGarbageCollection>

--- a/src/GRAL.csproj
+++ b/src/GRAL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <VersionPrefix>23.11.6</VersionPrefix>
+    <VersionPrefix>24.04.1</VersionPrefix>
     <Authors>Dietmar Oettl;Markus Kuntner</Authors>
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyTitle>GRAL</AssemblyTitle>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -66,7 +66,7 @@ namespace GRAL_2001
             Console.WriteLine("");
             Console.WriteLine("+------------------------------------------------------+");
             Console.WriteLine("|                                                      |");
-            string Info =     "+  > >         G R A L VERSION: 24.09Beta6       < <   +";
+            string Info =     "+  > >         G R A L VERSION: 24.04            < <   +";
             Console.WriteLine(Info);
             if (RunOnUnix)
             {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -66,7 +66,7 @@ namespace GRAL_2001
             Console.WriteLine("");
             Console.WriteLine("+------------------------------------------------------+");
             Console.WriteLine("|                                                      |");
-            string Info =     "+  > >         G R A L VERSION: 23.11            < <   +";
+            string Info =     "+  > >         G R A L VERSION: 24.09Beta6       < <   +";
             Console.WriteLine(Info);
             if (RunOnUnix)
             {
@@ -90,7 +90,6 @@ namespace GRAL_2001
             // write zipped files?
             ResultFileZipped = false;
             
-            int SIMD = CheckSIMD();
             LogLevel = CheckCommandLineArguments(args);
 
             //Delete file Problemreport_GRAL.txt
@@ -166,18 +165,21 @@ namespace GRAL_2001
 
             //Reading building data
             //case 1: complex terrain
-            if (Topo == Consts.TerrainAvailable)
             {
-                InitGralTopography(SIMD);
-                ReaderClass.ReadBuildingsTerrain(Program.CUTK); //define buildings in GRAL
+                int SIMD = CheckSIMD();
+                if (Topo == Consts.TerrainAvailable)
+                {
+                    InitGralTopography(SIMD);
+                    ReaderClass.ReadBuildingsTerrain(Program.CUTK); //define buildings in GRAL
+                }
+                //flat terrain application
+                else
+                {
+                    InitGralFlat();
+                    ReaderClass.ReadBuildingsFlat(Program.CUTK); //define buildings in GRAL
+                }
             }
-            //flat terrain application
-            else
-            {
-                InitGralFlat();
-                ReaderClass.ReadBuildingsFlat(Program.CUTK); //define buildings in GRAL
-            }
-
+            
             // array declarations for prognostic and diagnostic flow field
             if ((FlowFieldLevel > Consts.FlowFieldNoBuildings) || (Topo == Consts.TerrainAvailable))
             {

--- a/src/ProgramDeclarations.cs
+++ b/src/ProgramDeclarations.cs
@@ -1257,6 +1257,11 @@ namespace GRAL_2001
         public static VegetationDepoVel VegetationDepoVelFactors = new VegetationDepoVel(1.5F, 3);
 
         ///<summary>
+        /// Use Vector512 class?
+        ///</summary>
+        public static bool UseVector512Class = false;
+
+        ///<summary>
         /// Deposition velocity factor within vegetation areas
         ///</summary>
         public readonly struct VegetationDepoVel

--- a/src/ProgramFunctions.cs
+++ b/src/ProgramFunctions.cs
@@ -14,6 +14,7 @@ using System;
 using System.IO;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
 using System.Threading;
 using System.Threading.Tasks;
 namespace GRAL_2001
@@ -309,7 +310,16 @@ namespace GRAL_2001
         private static int CheckSIMD()
         {
             int SIMD = Vector<float>.Count;
-            Console.WriteLine("SIMD - support: " + SIMD.ToString() + " float values  IsHardwareAccelerated: " + Vector.IsHardwareAccelerated.ToString());
+            if (Program.UseVector512Class && Vector512.IsHardwareAccelerated)
+            {
+                SIMD = Vector512<float>.Count;   
+                Console.WriteLine("SIMD - support: " + SIMD.ToString() + " float values  Using Vector512 extension"); 
+            }
+            else
+            {   
+                SIMD = Vector<float>.Count;
+                Console.WriteLine("SIMD - support: " + SIMD.ToString() + " float values  IsHardwareAccelerated: " + Vector.IsHardwareAccelerated.ToString());
+            }
             if (Vector.IsHardwareAccelerated == false)
             {
                 string err = "Your system does not support vectors. This results in a very slow flow field calculation. \n Try to use the latest .NetCore framework \n Press a key to continue.";
@@ -451,7 +461,7 @@ namespace GRAL_2001
         /// <summary>
         /// Init GRAL settings for a calculation in complex terrain
         /// </summary>
-        /// <param name="SIMD">Nukber of float values within a vector</param>
+        /// <param name="SIMD">Number of float values within a vector</param>
         private static void InitGralTopography(int SIMD)
         {
             //get the minimum and maximum elevation of the GRAMM orography
@@ -1084,9 +1094,9 @@ namespace GRAL_2001
                 double x0 = i * Program.GralDx;
                 double xmax = x0 + Program.GralDx;
 
-                Span<double> VolumeReduction = stackalloc double[Program.NS];
-                Span<float> HMin = stackalloc float[Program.NS];
-                Span<float> HMax = stackalloc float[Program.NS];
+                Span<double> VolumeReduction = new double[Program.NS];
+                Span<float> HMin = new float[Program.NS];
+                Span<float> HMax = new float[Program.NS];
 
                 for (int k = 0; k < HMin.Length; k++)
                 {
@@ -1184,8 +1194,8 @@ namespace GRAL_2001
             // loop over all concentration cells
             Parallel.For(0, Program.NXL, Program.pOptions, i =>
             {
-                Span<float> HMin = stackalloc float[Program.NS];
-                Span<float> HMax = stackalloc float[Program.NS];
+                Span<float> HMin = new float[Program.NS];
+                Span<float> HMax = new float[Program.NS];
 
                 for (int k = 0; k < HMin.Length; k++)
                 {

--- a/src/ReadBuildings.cs
+++ b/src/ReadBuildings.cs
@@ -285,6 +285,7 @@ namespace GRAL_2001
 
                     if (block > 0)
                     {
+                        CalculateSubDomainsForPrognosticWindSimulation();
                         return true;
                     }
                 }

--- a/src/ReadInDat.cs
+++ b/src/ReadInDat.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.Intrinsics;
 
 namespace GRAL_2001
 {
@@ -185,7 +186,7 @@ namespace GRAL_2001
                                         if (text.Length > 1 && text[1].Equals("1"))
                                         {
                                             Program.WriteASCiiResults = true;
-                                            Console.WriteLine("Write ASCii Results");
+                                            Console.WriteLine("Writing ASCii results activated");
                                         }
                                     }
                                 }
@@ -240,6 +241,25 @@ namespace GRAL_2001
                                         if (r == 0) //0: no GRAL Online Functions
                                         {
                                             Program.GRALOnlineFunctions = false;
+                                        }
+                                    }
+                                }
+                                catch
+                                { }
+                            }
+
+                            // Use Vector512 class - Opt Out feature
+                            if (sr.EndOfStream == false)
+                            {
+                                try
+                                {
+                                    _line++;
+                                    text = sr.ReadLine().Split(new char[] { ' ', ',', '\r', '\n', ';', '!' }, StringSplitOptions.RemoveEmptyEntries);
+                                    if (text.Length > 0 && int.TryParse(text[0], System.Globalization.NumberStyles.Any, ic, out int r))
+                                    {
+                                        if (r == 1 && Vector512.IsHardwareAccelerated)
+                                        {
+                                            Program.UseVector512Class = true;
                                         }
                                     }
                                 }

--- a/src/Transient_Concentration.cs
+++ b/src/Transient_Concentration.cs
@@ -14,7 +14,7 @@ using System.Runtime.CompilerServices;
 
 namespace GRAL_2001
 {
-    class TransientConcentration
+    internal class TransientConcentration
     {
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace GRAL_2001
         /// <param name="xsi">Particle x position</param>
         /// <param name="eta">Particle y position</param>
         /// <param name="SG_nteil">internal source group number of this particle</param>
-        public void Conz5dZeitschleife(int reflexion_flag, float zcoord_nteil, float AHint, double masse, double Area_cart, float idt, double xsi, double eta, int SG_nteil)
+        public static void Conz5dZeitschleife(int reflexion_flag, float zcoord_nteil, float AHint, double masse, double Area_cart, float idt, double xsi, double eta, int SG_nteil)
         {
             if (reflexion_flag == 0)
             {
@@ -38,7 +38,7 @@ namespace GRAL_2001
                 int IndexJ3d = (int)(eta / Program.DYK) + 1;
 
                 float[] conz5d_L = Program.Conz5d[IndexI3d][IndexJ3d][IndexK3d];
-                lock (conz5d_L)
+                lock (conz5d_L.SyncRoot)
                 {
                     conz5d_L[SG_nteil] += (float)(masse * Program.GridVolume * Program.TAUS / (Area_cart * Program.DZK_Trans[IndexK3d]));
                 }
@@ -57,7 +57,7 @@ namespace GRAL_2001
         /// <param name="xsi">Particle x position</param>
         /// <param name="eta">Particle y position</param>
         /// <param name="SG_nteil">internal source group number of this particle</param>
-        public void Conz5dZeitschleifeTransient(int reflexion_flag, float zcoord_nteil, float AHint, double mass_real, double Area_cart, float idt, double xsi, double eta, int SG_nteil)
+        public static void Conz5dZeitschleifeTransient(int reflexion_flag, float zcoord_nteil, float AHint, double mass_real, double Area_cart, float idt, double xsi, double eta, int SG_nteil)
         {
             if (reflexion_flag == 0)
             {
@@ -66,7 +66,7 @@ namespace GRAL_2001
                 int IndexJ3d = (int)(eta / Program.DYK) + 1;
 
                 float[] conz5d_L = Program.Conz5d[IndexI3d][IndexJ3d][IndexK3d];
-                lock (conz5d_L)
+                lock (conz5d_L.SyncRoot)
                 {
                     conz5d_L[SG_nteil] += (float)(mass_real * Program.TAUS / (Area_cart * Program.DZK_Trans[IndexK3d]));
                 }

--- a/src/U-prognostic-microscale_1_Vec512.cs
+++ b/src/U-prognostic-microscale_1_Vec512.cs
@@ -1,0 +1,530 @@
+#region Copyright
+///<remarks>
+/// <Graz Lagrangian Particle Dispersion Model>
+/// Copyright (C) [2019]  [Dietmar Oettl, Markus Kuntner]
+/// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation version 3 of the License
+/// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+/// You should have received a copy of the GNU General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+///</remarks>
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Collections.Concurrent;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace GRAL_2001
+{
+    public static class U_PrognosticMicroscaleV1_Vec512
+    {
+        static readonly Vector512<float> Vect_0 = Vector512<float>.Zero;
+        static readonly Vector512<float> Vect_1 = Vector512<float>.One;
+        static readonly Vector512<float> Vect_01 = Vector512.Create(0.1F);
+        static readonly Vector512<float> Vect_025 = Vector512.Create(0.25F);
+        static readonly Vector512<float> Vect_05 = Vector512.Create(0.5F);
+        static readonly Vector512<float> Vect_099 = Vector512.Create(0.99F);
+        static readonly Vector512<float> Vect_0071 = Vector512.Create(0.071F);
+        static readonly Vector512<float> Vect_2 = Vector512.Create(2F);
+        static readonly Vector512<float> Vect_001 = Vector512.Create(0.01F);
+        static readonly Vector512<float> Vect_15 = Vector512.Create(15F);
+        static readonly Vector512<float> Vect_100 = Vector512.Create(100F);
+        static readonly Vector512<float> Vect_0001 = Vector512.Create(0.0001F);
+        
+        /// <summary>
+        /// Momentum equations for the u wind component - algebraic mixing lenght model
+        /// </summary>
+        /// <param name="IS">ADI direction for x cells</param>
+        /// <param name="JS">ADI direction for y cells</param>
+        /// <param name="Cmueh">Constant</param>
+        /// <param name="VISHMIN">Minimum horizontal turbulent exchange coefficients </param>
+        /// <param name="AREAxy">Area of a flow field cell</param>
+        /// <param name="UG">Geostrophic wind</param>
+        /// <param name="building_Z0">Roughness of buildings</param>
+        /// <param name="relax">Relaxation factor</param>
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        [SkipLocalsInit]
+        public static void Calculate(int IS, int JS, float Cmueh, float VISHMIN, float AREAxy, Single UG, float relax)
+        {
+            float DXK = Program.DXK; float DYK = Program.DYK;
+            Vector512<float> DXK_V = Vector512.Create(DXK);
+            Vector512<float> DYK_V = Vector512.Create(DYK);
+            Vector512<float> VISHMIN_V = Vector512.Create(VISHMIN);
+            Vector512<float> AREAxy_V = Vector512.Create(AREAxy);
+            Vector512<float> UG_V = Vector512.Create(UG);
+            
+            int maxTasks = Math.Max(1, Program.IPROC + Math.Abs(Environment.TickCount % 8));
+            int minL = Math.Min(64, Program.NII - 4); // Avoid too large slices due to perf issues
+            Parallel.ForEach(Partitioner.Create(3, Program.NII, Math.Min(Math.Max(4, (Program.NII / maxTasks)), minL)), Program.pOptions, range =>
+            //Parallel.For(3, Program.NII, Program.pOptions, i1 =>
+            {
+                Span<float> PIMU = stackalloc float[Program.KADVMAX + 1];
+                Span<float> QIMU = stackalloc float[Program.KADVMAX + 1];
+                Span<float> Mask = stackalloc float[Vector512<float>.Count];
+                Span<float> Mask2 = stackalloc float[Vector512<float>.Count];
+                Span<float> AIM_A = stackalloc float[Vector512<float>.Count];
+                Span<float> BIM_A = stackalloc float[Vector512<float>.Count];
+                Span<float> CIM_A = stackalloc float[Vector512<float>.Count];
+                Span<float> DIMU_A = stackalloc float[Vector512<float>.Count];
+
+                Vector512<float> DVDXN, DVDXS, DUDXE, DUDXW, DWDXT, DWDXB;
+                Vector512<float> DE, DW, DS, DN, DT, DB;
+                Vector512<float> FE, FW, FS, FN, FT, FB;
+                Vector512<float> PE, PW, PS, PN, PT, PB;
+                Vector512<float> BIM, CIM, AE1, AW1, AS1, AN1, AIM;
+                Vector512<float> DIM_U, windhilf;
+                Vector512<float> DDPX;
+
+                Vector512<float> UKS_W_LV;
+                Vector512<float> VKS_S_LV, WKS_W_LV, WKS_WB_LV, WKS_WBm_LV, WKS_B_LV, WKS_Bp_LV;
+
+                Vector512<float> VKS_WS_LV, VKS_WN_LV, VKS_E_LV, UK_E_LV, VKS_W_LV;
+
+                Vector512<float> WKS_V, VKS_V, UKS_V, DZK_V;
+                Vector512<float> DXKDZK, DYKDZK, AP0_V, intern, intern2;
+
+                Vector512<float> VIS, zs, mixL;
+                Vector512<float> UK_LV, UK_W_LV;
+                Vector512<float> HOKART_KKART_V;
+
+                Vector512<float> Mask_V = Vector512<float>.Zero;
+                Vector512<float> DUDZ, DVDZ;
+                Vector512<float> Coriolis = Vector512.Create(Program.CorolisParam);
+
+                for (int i1 = range.Item1; i1 < range.Item2; i1++)
+                {
+                    int i = i1;
+                    if (IS == -1)
+                    {
+                        i = Program.NII - i1 + 1;
+                    }
+
+                    for (int j1 = 2; j1 <= Program.NJJ - 1; ++j1)
+                    {
+                        int j = j1;
+                        if (JS == -1)
+                        {
+                            j = Program.NJJ - j1 + 1;
+                        }
+
+                        if (Program.ADVDOM[i][j] == 1)
+                        {
+                            //inside a prognostic sub domain
+                            int jM1 = j - 1;
+                            int jP1 = j + 1;
+                            int iM1 = i - 1;
+                            int iP1 = i + 1;
+
+                            float[] UK_L = Program.UK[i][j];
+                            Single[] UKS_L = Program.UKS[i][j];
+                            Single[] VKS_L = Program.VKS[i][j];
+                            Single[] WKS_L = Program.WKS[i][j];
+                            Single[] DPMNEW_L = Program.DPMNEW[i][j];
+                            Single[] UK_W_L = Program.UK[iM1][j];
+                            Single[] UK_E_L = Program.UK[iP1][j];
+                            Single[] UK_S_L = Program.UK[i][jM1];
+                            Single[] UK_N_L = Program.UK[i][jP1];
+                            Single[] UKS_W_L = Program.UKS[iM1][j];
+                            Single[] VKS_W_L = Program.VKS[iM1][j];
+                            Single[] VKS_WS_L = Program.VKS[iM1][jM1];
+                            Single[] VKS_S_L = Program.VKS[i][jM1];
+                            Single[] VKS_WN_L = Program.VKS[iM1][jP1];
+                            Single[] VKS_N_L = Program.VKS[i][jP1];
+                            Single[] WKS_W_L = Program.WKS[iM1][j];
+                            Single[] DPMNEW_W_L = Program.DPMNEW[iM1][j];
+
+                            Single[] VKS_EN_L = Program.VKS[iP1][jP1];
+                            Single[] VKS_ES_L = Program.VKS[iP1][jM1];
+                            Single[] WKS_E_L = Program.WK[iP1][j];
+                            Single[] VK_L = Program.VK[i][j];
+
+                            int Vert_Index_LL = Program.VerticalIndex[i][j];
+                            float Ustern_terrain_helpterm = Program.UsternTerrainHelpterm[i][j];
+                            float Ustern_obstacles_helpterm = Program.UsternObstaclesHelpterm[i][j];
+                            //At a boundary of the prognostic domain?
+                            bool ADVDOM_S = (Program.ADVDOM[i][jM1] < 1) || (j == 2);
+                            bool ADVDOM_N = (Program.ADVDOM[i][jP1] < 1) || (j == Program.NJJ - 1);
+                            bool ADVDOM_W = (Program.ADVDOM[iM1][j] < 1) || (i == 2);
+                            bool ADVDOM_E = (Program.ADVDOM[iP1][j] < 1) || (i == Program.NII - 1);
+
+                            float CUTK_L = Program.CUTK[i][j];
+                            Single[] VEG_L = Program.VEG[i][j];
+                            Single COV_L = Program.COV[i][j];
+
+                            float Z0 = Program.Z0;
+                            if (Program.AdaptiveRoughnessMax < 0.01)
+                            {
+                                //Use GRAMM Roughness with terrain or Roughness from point 1,1 without terrain
+                                int IUstern = 1;
+                                int JUstern = 1;
+                                if ((Program.Topo == Consts.TerrainAvailable) && (Program.LandUseAvailable == true))
+                                {
+                                    double x = i * Program.DXK + Program.GralWest;
+                                    double y = j * Program.DYK + Program.GralSouth;
+                                    double xsi1 = x - Program.GrammWest;
+                                    double eta1 = y - Program.GrammSouth;
+                                    IUstern = Math.Clamp((int)(xsi1 / Program.DDX[1]) + 1, 1, Program.NX);
+                                    JUstern = Math.Clamp((int)(eta1 / Program.DDY[1]) + 1, 1, Program.NY);
+                                }
+                                Z0 = Program.Z0Gramm[IUstern][JUstern];
+                            }
+                            else
+                            {
+                                Z0 = Program.Z0Gral[i][j];
+                            }
+
+                            int KKART_LL = Program.KKART[i][j];
+                            HOKART_KKART_V = Vector512.Create(Program.HOKART[KKART_LL]);
+
+                            int KSTART = 1;
+                            if (CUTK_L == 0) // building heigth == 0 m
+                            {
+                                KSTART = KKART_LL + 1;
+                            }
+
+                            int KKART_LL_P1 = KKART_LL + 1;
+
+                            int KEND = Vert_Index_LL + 1; // simpify for-loop
+                            bool end = false; // flag for the last loop 
+                            int k_real = 0;
+                            bool VegetationExists = VEG_L != null;
+                            
+                            for (int k = KSTART; k < KEND; k += Vector512<float>.Count)
+                            {
+                                // to compute the top levels - reduce k, remember k_real and set end to true
+                                k_real = k;
+                                if (k > KEND - Vector512<float>.Count)
+                                {
+                                    k = KEND - Vector512<float>.Count;
+                                    end = true;
+                                }
+                                int kM1 = k - 1;
+                                int kP1 = k + 1;
+
+                                WKS_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_L), (uint) k);
+                                VKS_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_L), (uint) k);
+                                UKS_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_L), (uint) k);
+                                DZK_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(Program.DZK), (uint) k);
+
+                                DXKDZK = Avx512F.Multiply(DXK_V, DZK_V);
+                                DYKDZK = Avx512F.Multiply(DYK_V, DZK_V);
+
+                                //turbulence modelling
+                                zs = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(Program.HOKART), (uint) k) - Avx512F.FusedMultiplyAdd(DZK_V, Vect_05, HOKART_KKART_V);
+
+                                VIS = Vector512<float>.Zero;
+
+                                // Create Mask if KKART_LL is between k and k + Vector512<float>.Count
+                                bool mask_v_enable = false;
+                                if (KKART_LL_P1 >= k && KKART_LL_P1 < (k + Vector512<float>.Count))
+                                {
+                                    for (int ii = 0; ii < Mask.Length; ++ii)
+                                    {
+                                        if ((k + ii) > KKART_LL_P1)
+                                        {
+                                            Mask[ii] = 1;
+                                        }
+                                        else
+                                        {
+                                            Mask[ii] = 0;
+                                        }
+                                    }
+                                    Mask_V = Vector512.Create<float>(Mask);
+                                    mask_v_enable = true;
+                                }
+                                else
+                                {
+                                     Mask_V = Vector512<float>.One;
+                                }
+
+                                if ((k + Vector512<float>.Count) > KKART_LL_P1)
+                                {
+                                    //k-eps model
+                                    //float VIS = (float)Math.Sqrt(TURB_L[k]) * zs * Cmueh;
+
+                                    //mixing-length model
+                                    mixL = Vector512.Min<float>(Avx512F.Multiply(Vect_0071, zs), Vect_100);
+
+                                    //adapted mixing-leng th within vegetation layers
+                                    if (COV_L > 0)
+                                    {
+                                        mixL = Avx512F.Multiply(mixL, (Vect_1 - Avx512F.Multiply(Vect_099, Vector512.Create<float>(COV_L))));
+                                        //mixL = (float)Math.Min(0.071 * Math.Max(1 - Math.Min(2 * VEG_L[kM1], 1), 0.05) * zs, 100);
+                                    }
+
+                                    intern = Avx512F.Divide(Avx512F.Subtract(Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_L), (uint)kP1), Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_L), (uint)kM1)),
+                                    Avx512F.Multiply(Vect_2, DZK_V));
+                                    DUDZ = Avx512F.Multiply(intern, intern);
+
+                                    intern = Avx512F.Divide(Avx512F.Subtract(Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_L), (uint)kP1), Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_L), (uint)kM1)),
+                                    Avx512F.Multiply(Vect_2, DZK_V));
+                                    DVDZ = Avx512F.Multiply(intern, intern);
+
+                                    VIS = Vector512.Min<float>(Avx512F.Multiply(Avx512F.Multiply(mixL, mixL), Vector512.Sqrt<float>(Avx512F.Multiply(Vect_05, (DUDZ + DVDZ)))), Vect_15) * Mask_V;
+                                }
+
+                                //Diffusion terms
+                                DE = Avx512F.Divide(Avx512F.Multiply(Vector512.Max<float>(VIS, VISHMIN_V), DYKDZK), DXK_V);
+                                DW = DE;
+                                DS = Avx512F.Divide(Avx512F.Multiply(Vector512.Max<float>(VIS, VISHMIN_V), DXKDZK), DYK_V);
+                                DN = DS;
+                                DT = Avx512F.Divide(Avx512F.Multiply(Vector512.Max<float>(VIS, VISHMIN_V), AREAxy_V), DZK_V);
+                                DB = Vector512<float>.Zero;
+                                if (mask_v_enable)
+                                {
+                                    DB = Avx512F.Multiply(DT, Mask_V);
+                                }
+                                else if (k > KKART_LL_P1) // otherwise k < KKART_LL_P1 and DB=0!
+                                {
+                                    DB = DT;
+                                }
+
+                                //BOUNDARY CONDITIONS FOR DIFFUSION TERMS
+                                if (ADVDOM_S)
+                                {
+                                    DS = Vector512<float>.Zero;
+                                }
+                                if (ADVDOM_N)
+                                {
+                                    DN = Vector512<float>.Zero;
+                                }
+                                if (ADVDOM_W)
+                                {
+                                    DW = Vector512<float>.Zero;
+                                }
+                                if (ADVDOM_E)
+                                {
+                                    DE = Vector512<float>.Zero;
+                                }
+
+                                //ADVECTION TERMS
+                                VKS_WN_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_WN_L), (uint) k);
+                                VKS_E_LV =  Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_N_L), (uint) k);
+                                VKS_W_LV =  Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_W_L), (uint) k);
+                                VKS_WS_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_WS_L), (uint) k);
+                                VKS_S_LV =  Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_S_L), (uint) k);
+                                UKS_W_LV =  Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_W_L), (uint) k);
+                                
+                                WKS_B_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_L), (uint) kM1);
+                                WKS_Bp_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_L), (uint) kP1);
+
+                                WKS_W_LV =  Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_W_L), (uint) k);
+                                WKS_WB_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_W_L), (uint) kM1);
+                                WKS_WBm_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_W_L), (uint) kP1);
+
+                                FE = Avx512F.Multiply(UKS_V, DYKDZK);
+                                FW = Avx512F.Multiply(UKS_W_LV, DYKDZK);
+                                FS = Avx512F.Multiply(Avx512F.Multiply(Vect_025,
+                                     Avx512F.Add(Avx512F.Add(Avx512F.Add(VKS_W_LV, VKS_V), VKS_WS_LV), VKS_S_LV)), DXKDZK);
+                                FN = Avx512F.Multiply(Avx512F.Multiply(Vect_025,
+                                     Avx512F.Add(Avx512F.Add(Avx512F.Add(VKS_W_LV, VKS_V), VKS_WN_LV), VKS_E_LV)), DXKDZK);
+                                FT = Avx512F.Multiply(Avx512F.Multiply(Vect_025,
+                                     Avx512F.Add(Avx512F.Add(Avx512F.Add(WKS_W_LV, WKS_V), WKS_WBm_LV), WKS_Bp_LV)), AREAxy_V);
+                                FB = Vector512<float>.Zero;
+
+                                if (mask_v_enable)
+                                {
+                                    FB = Avx512F.Multiply(Avx512F.Multiply(Vect_025, Avx512F.Add(Avx512F.Add(Avx512F.Add(WKS_W_LV, WKS_V), WKS_WB_LV), WKS_B_LV)), AREAxy_V) * Mask_V;
+                                }
+                                else if (k > KKART_LL_P1) // otherwise k < KKART_LL_P1 and FB=0!
+                                {
+                                    FB = Avx512F.Multiply(Avx512F.Multiply(Vect_025, Avx512F.Add(Avx512F.Add(Avx512F.Add(WKS_W_LV, WKS_V), WKS_WB_LV), WKS_B_LV)), AREAxy_V);
+                                }
+
+                                //PECLET NUMBERS
+                                DE = Vector512.Max<float>(DE, Vect_0001);
+                                DB = Vector512.Max<float>(DB, Vect_0001);
+                                DW = Vector512.Max<float>(DW, Vect_0001);
+                                DS = Vector512.Max<float>(DS, Vect_0001);
+                                DN = Vector512.Max<float>(DN, Vect_0001);
+                                DT = Vector512.Max<float>(DT, Vect_0001);
+
+                                PE = Vector512.Abs<float>(FE / DE);
+                                PB = Vector512.Abs<float>(FB / DB);
+                                PW = Vector512.Abs<float>(FW / DW);
+                                PS = Vector512.Abs<float>(FS / DS);
+                                PN = Vector512.Abs<float>(FN / DN);
+                                PT = Vector512.Abs<float>(FT / DT);
+
+                                //POWER LAW ADVECTION SCHEME
+                                intern = Vect_1 - Vect_01 * PT;
+                                BIM = Avx512F.FusedMultiplyAdd(DT, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(-FT, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PB;
+                                CIM = Avx512F.FusedMultiplyAdd(DB, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(FB, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PE;
+                                AE1 = Avx512F.FusedMultiplyAdd(DE, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(-FE, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PW;
+                                AW1 = Avx512F.FusedMultiplyAdd(DW, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(FW, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PS;
+                                AS1 = Avx512F.FusedMultiplyAdd(DS, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(FS, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PN;
+                                AN1 = Avx512F.FusedMultiplyAdd(DN, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(-FN, Vect_0));
+
+                                //UPWIND SCHEME
+                                /*
+                                    double BIM = DT + Program.fl_max(-FT, 0);
+                                    double CIM = DB + Program.fl_max(FB, 0);
+                                    double AE1 = DE + Program.fl_max(-FE, 0);
+                                    double AW1 = DW + Program.fl_max(FW, 0);
+                                    double AS1 = DS + Program.fl_max(FS, 0);
+                                    double AN1 = DN + Program.fl_max(-FN, 0);
+                                 */
+
+                                AP0_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(PrognosticFlowfield.AP0), (uint) k);
+                                AIM = Avx512F.Add(Avx512F.Add(Avx512F.Add(Avx512F.Add(Avx512F.Add(Avx512F.Add(BIM, CIM), AW1), AS1), AE1), AN1), AP0_V);
+
+                                //SOURCE TERMS
+                                DDPX =     Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(DPMNEW_W_L), (uint) k) - Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(DPMNEW_L), (uint) k);
+                                UK_W_LV =  Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_W_L), (uint) k);
+                                UK_E_LV =  Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_E_L), (uint) k);
+                                UKS_W_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_W_L), (uint) k);
+                                UK_LV =    Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_L), (uint) k);
+
+                                if (VegetationExists)
+                                {
+                                    intern2 = Avx512F.Multiply(Vect_05, (VKS_W_LV + VKS_V));
+                                    intern = Avx512F.Multiply(Vect_05, (UKS_W_LV + UKS_V));
+                                    windhilf = Vector512.Max<float>(Vector512.Sqrt<float>(Avx512F.Multiply(intern, intern) + Avx512F.Multiply(intern2, intern2)), Vect_001);
+                                    DIM_U = Avx512F.FusedMultiplyAdd(AW1, UK_W_LV,
+                                            AS1 * Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_S_L), (uint) k)) +
+                                            Avx512F.FusedMultiplyAdd(AE1, UK_E_LV,
+                                            AN1 * Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_N_L), (uint) k)) +
+                                            AP0_V * Vect_05 * (UKS_W_LV + UKS_V) +
+                                            DDPX * DYKDZK +
+                                            (Avx512F.Multiply(Coriolis, Avx512F.Subtract(UG_V, UK_LV)) -
+                                            Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VEG_L), (uint) kM1) * UK_LV * windhilf) * AREAxy_V * DZK_V;
+                                }
+                                else
+                                {
+                                    DIM_U = Avx512F.FusedMultiplyAdd(AW1, UK_W_LV,
+                                            AS1 * Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_S_L), (uint) k)) +
+                                            Avx512F.FusedMultiplyAdd(AE1, UK_E_LV,
+                                            AN1 * Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_N_L), (uint) k)) +
+                                            AP0_V * Vect_05 * (UKS_W_LV + UKS_V) +
+                                            Avx512F.FusedMultiplyAdd(DDPX, DYKDZK,
+                                            Avx512F.Multiply(Avx512F.Multiply(Avx512F.Multiply(Coriolis, Avx512F.Subtract(UG_V,UK_LV)), AREAxy_V), DZK_V));
+                                }
+
+                                //BOUNDARY CONDITION AT SURFACES (OBSTACLES AND TERRAIN)
+                                if ((k <= KKART_LL_P1) && ((k + Vector512<float>.Count) > KKART_LL_P1))
+                                {
+                                    Mask2.Clear();
+                                    //Array.Clear(Mask2, 0, Mask2.Length);
+                                    int ii = KKART_LL_P1 - k;   // 0 to SIMD - 1
+                                    Mask2[ii] = 1;              // Set the mask2 at SIMD position k == KKART_LL_P1 to 1
+
+                                    intern = Avx512F.Multiply(Vect_05, (UKS_W_LV + UKS_V));
+                                    intern2 = Avx512F.Multiply(Vect_05, (VKS_W_LV + VKS_V));
+                                    windhilf = Vector512.Max<float>(Vector512.Sqrt<float>(Avx512F.Multiply(intern, intern) + Avx512F.Multiply(intern2, intern2)), Vect_01);
+
+                                    if (CUTK_L < 1) // building heigth < 1 m
+                                    {
+                                        // above terrain
+                                        float Ustern_Buildings = Ustern_terrain_helpterm * windhilf[ii];
+                                        if (Z0 >= DZK_V[ii] * 0.1F)
+                                        {
+                                            int ind = k + ii + 1;
+                                            Ustern_Buildings = Ustern_terrain_helpterm * MathF.Sqrt(Program.Pow2(0.5F * ((UKS_W_L[ind]) + UKS_L[ind])) + Program.Pow2(0.5F * ((VKS_W_L[ind]) + VKS_L[ind])));
+                                        }
+
+                                        Vector512<float> Ustern_Buildings_V = Vector512.Create(Ustern_Buildings * Ustern_Buildings);
+                                        DIM_U -= UK_LV / windhilf * Ustern_Buildings_V * AREAxy_V * Vector512.Create<float>(Mask2);
+                                    }
+                                    else
+                                    {
+                                        //above a building
+                                        float Ustern_Buildings = Ustern_obstacles_helpterm * windhilf[ii];
+                                        Vector512<float> Ustern_Buildings_V = Vector512.Create(Ustern_Buildings * Ustern_Buildings);
+                                        DIM_U -= UK_LV / windhilf * Ustern_Buildings_V * AREAxy_V * Vector512.Create<float>(Mask2);
+                                    }
+                                }
+
+                                //additional terms of the eddy-viscosity model
+                                if (k > KKART_LL_P1)
+                                {
+                                    DUDXE = (UK_E_LV - UK_LV) * DYKDZK;
+                                    DUDXW = (UK_LV - UK_W_LV) * DYKDZK;
+                                    DVDXN = (Vect_05 * (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_EN_L), (uint) k) + VKS_E_LV) - Vect_05 * (VKS_E_LV + VKS_WN_LV)) * DXKDZK;
+                                    DVDXS = (Vect_05 * (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_ES_L), (uint) k) + VKS_S_LV) - Vect_05 * (VKS_S_LV + VKS_WS_LV)) * DXKDZK;
+                                    DWDXT = (Vect_05 * (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_E_L), (uint) k) + WKS_V) - Vect_05 * (WKS_V + WKS_W_LV)) * AREAxy_V;
+                                    DWDXB = (Vect_05 * (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_E_L), (uint) kM1) + WKS_B_LV) - Vect_05 * (WKS_B_LV + WKS_WB_LV)) * AREAxy_V;
+
+                                    DIM_U += VIS / DXK_V * (DUDXE - DUDXW + DVDXN - DVDXS + DWDXT - DWDXB) * Mask_V;
+                                }
+
+                                //RECURRENCE FORMULA
+                                int kint_s = 0;
+                                if (end) // restore original indices 
+                                {
+                                    kint_s = k_real - k;
+                                    k_real -= kint_s;
+                                }
+
+                                Vector512.StoreUnsafe<float>(AIM, ref AIM_A[0]);
+                                Vector512.StoreUnsafe<float>(BIM, ref BIM_A[0]);
+                                Vector512.StoreUnsafe<float>(CIM, ref CIM_A[0]);
+                                Vector512.StoreUnsafe<float>(DIM_U, ref DIMU_A[0]);
+
+                                for (int kint = kint_s; kint < AIM_A.Length; ++kint) // loop over all SIMD values
+                                {
+                                    int index_i = k_real + kint;
+
+                                    if (index_i < KEND)
+                                    {
+                                        if (index_i > KKART_LL_P1)
+                                        {
+                                            float TERMP = 1 / (AIM_A[kint] - CIM_A[kint] * PIMU[index_i - 1]);
+                                            PIMU[index_i] = BIM_A[kint] * TERMP;
+                                            QIMU[index_i] = (DIMU_A[kint] + CIM_A[kint] * QIMU[index_i - 1]) * TERMP;
+                                        }
+                                        else
+                                        {
+                                            float TERMP = 1 / AIM_A[kint];
+                                            PIMU[index_i] = BIM_A[kint] * TERMP;
+                                            QIMU[index_i] = DIMU_A[kint] * TERMP;
+                                        }
+                                    }
+                                }
+
+                                if (end)
+                                {
+                                    k = KEND + 1;
+                                }
+
+                            } // loop over all k
+
+                            //OBTAIN NEW U-COMPONENTS
+                            int KKARTm_LL = Math.Max(KKART_LL, Program.KKART[i - 1][j]);
+                            lock (UK_L)
+                            {
+                                for (int k = Vert_Index_LL; k >= KSTART; --k)
+                                {
+                                    if (KKARTm_LL < k)
+                                    {
+                                        UK_L[k] += relax * (PIMU[k] * UK_L[k + 1] + QIMU[k] - UK_L[k]);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/U-prognostic-microscale_1_Vec512.cs
+++ b/src/U-prognostic-microscale_1_Vec512.cs
@@ -1,7 +1,7 @@
 #region Copyright
 ///<remarks>
 /// <Graz Lagrangian Particle Dispersion Model>
-/// Copyright (C) [2019]  [Dietmar Oettl, Markus Kuntner]
+/// Copyright (C) [2024] [Markus Kuntner] Predecessor: [2019]  [Dietmar Oettl, Markus Kuntner]
 /// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
 /// the Free Software Foundation version 3 of the License
 /// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/V-prognostic-microscale_1_Vec512.cs
+++ b/src/V-prognostic-microscale_1_Vec512.cs
@@ -1,7 +1,7 @@
 #region Copyright
 ///<remarks>
 /// <Graz Lagrangian Particle Dispersion Model>
-/// Copyright (C) [2019]  [Dietmar Oettl, Markus Kuntner]
+/// Copyright (C) [2024] [Markus Kuntner] Predecessor: [2019]  [Dietmar Oettl, Markus Kuntner]
 /// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
 /// the Free Software Foundation version 3 of the License
 /// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/V-prognostic-microscale_1_Vec512.cs
+++ b/src/V-prognostic-microscale_1_Vec512.cs
@@ -1,0 +1,526 @@
+#region Copyright
+///<remarks>
+/// <Graz Lagrangian Particle Dispersion Model>
+/// Copyright (C) [2019]  [Dietmar Oettl, Markus Kuntner]
+/// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation version 3 of the License
+/// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+/// You should have received a copy of the GNU General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+///</remarks>
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Collections.Concurrent;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace GRAL_2001
+{
+    public static class V_PrognosticMicroscaleV1_Vec512
+    {
+        static readonly Vector512<float> Vect_0 = Vector512<float>.Zero;
+        static readonly Vector512<float> Vect_1 = Vector512<float>.One;
+        static readonly Vector512<float> Vect_01 = Vector512.Create(0.1F);
+        static readonly Vector512<float> Vect_025 = Vector512.Create(0.25F);
+        static readonly Vector512<float> Vect_05 = Vector512.Create(0.5F);
+        static readonly Vector512<float> Vect_099 = Vector512.Create(0.99F);
+        static readonly Vector512<float> Vect_0071 = Vector512.Create(0.071F);
+        static readonly Vector512<float> Vect_2 = Vector512.Create(2F);
+        static readonly Vector512<float> Vect_001 = Vector512.Create(0.01F);
+        static readonly Vector512<float> Vect_15 = Vector512.Create(15F);
+        static readonly Vector512<float> Vect_100 = Vector512.Create(100F);
+        static readonly Vector512<float> Vect_0001 = Vector512.Create(0.0001F);
+        
+        /// <summary>
+        /// Momentum equations for the v wind component - algebraic mixing lenght model
+        /// </summary>   
+        /// <param name="IS">ADI direction for x cells</param>
+        /// <param name="JS">ADI direction for y cells</param>
+        /// <param name="Cmueh">Constant</param>
+        /// <param name="VISHMIN">Minimum horizontal turbulent exchange coefficients </param>
+        /// <param name="AREAxy">Area of a flow field cell</param>
+        /// <param name="VG">Geostrophic wind</param>
+        /// <param name="building_Z0">Roughness of buildings</param>
+        /// <param name="relax">Relaxation factor</param>
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        [SkipLocalsInit]
+        public static void Calculate(int IS, int JS, float Cmueh, float VISHMIN, float AREAxy, Single VG, float relax)
+        {
+            float DXK = Program.DXK; float DYK = Program.DYK;
+            Vector512<float> DXK_V = Vector512.Create(DXK);
+            Vector512<float> DYK_V = Vector512.Create(DYK);
+            Vector512<float> VISHMIN_V = Vector512.Create(VISHMIN);
+            Vector512<float> AREAxy_V = Vector512.Create(AREAxy);
+            Vector512<float> VG_V = Vector512.Create(VG);
+            
+            int maxTasks = Math.Max(1, Program.IPROC + Math.Abs(Environment.TickCount % 8));
+            int minL = Math.Min(64, Program.NII - 4); // Avoid too large slices due to perf issues
+            Parallel.ForEach(Partitioner.Create(2, Program.NII, Math.Min(Math.Max(4, (Program.NII / maxTasks)), minL)), Program.pOptions, range =>
+            //Parallel.For(2, Program.NII, Program.pOptions, i1 =>
+            {
+                Span<float> PIMV = stackalloc float[Program.KADVMAX + 1];
+                Span<float> QIMV = stackalloc float[Program.KADVMAX + 1];
+                Span<float> Mask   = stackalloc float[Vector512<float>.Count];
+                Span<float> Mask2  = stackalloc float[Vector512<float>.Count];
+                Span<float> AIM_A  = stackalloc float[Vector512<float>.Count];
+                Span<float> BIM_A  = stackalloc float[Vector512<float>.Count];
+                Span<float> CIM_A  = stackalloc float[Vector512<float>.Count];
+                Span<float> DIMV_A = stackalloc float[Vector512<float>.Count];
+
+                Vector512<float> DVDYN, DVDYS, DUDYE, DUDYW, DWDYT, DWDYB;
+                Vector512<float> DE, DW, DS, DN, DT, DB;
+                Vector512<float> FE, FW, FS, FN, FT, FB;
+                Vector512<float> PE, PW, PS, PN, PT, PB;
+                Vector512<float> BIM, CIM, AE1, AW1, AS1, AN1, AIM;
+                Vector512<float> DIMV, windhilf;
+                Vector512<float> DDPY;
+
+                Vector512<float> UKS_E_LV, UKS_N_LV, UKS_ES_LV, UKS_W_LV, UKS_WS_LV, VK_N_LV, VK_S_LV, VKS_W_LV;
+                Vector512<float> VKS_S_LV, WKS_S_LV, WKS_Sm_LV, WKS_B_LV;
+
+                Vector512<float> WKS_V, VKS_V, UKS_V, DZK_V;
+                Vector512<float> DXKDZK, DYKDZK, AP0_V, intern, intern2;
+
+                Vector512<float> VIS, zs, mixL;
+                Vector512<float> VK_LV;
+                Vector512<float> HOKART_KKART_V;
+
+                Vector512<float> Mask_V = Vector512<float>.Zero;
+                Vector512<float> DUDZ, DVDZ;
+                Vector512<float> Coriolis = Vector512.Create(Program.CorolisParam);
+
+                for (int i1 = range.Item1; i1 < range.Item2; i1++)
+                {
+                    int i = i1;
+                    if (IS == -1)
+                    {
+                        i = Program.NII - i1 + 1;
+                    }
+
+                    for (int j1 = 3; j1 <= Program.NJJ - 1; ++j1)
+                    {
+                        int j = j1;
+                        if (JS == -1)
+                        {
+                            j = Program.NJJ - j1 + 1;
+                        }
+
+                        if (Program.ADVDOM[i][j] == 1)
+                        {
+                            //inside a prognostic sub domain
+                            int jM1 = j - 1;
+                            int jP1 = j + 1;
+                            int iM1 = i - 1;
+                            int iP1 = i + 1;
+
+                            float[] VK_L = Program.VK[i][j];
+                            
+                            Single[] UKS_L = Program.UKS[i][j];
+                            Single[] VKS_L = Program.VKS[i][j];
+                            Single[] WKS_L = Program.WKS[i][j];
+                            Single[] DPMNEW_L = Program.DPMNEW[i][j];
+                            Single[] VK_W_L = Program.VK[iM1][j];
+                            Single[] VK_E_L = Program.VK[iP1][j];
+                            Single[] VK_S_L = Program.VK[i][jM1];
+                            Single[] VK_N_L = Program.VK[i][jP1];
+                            Single[] UKS_W_L = Program.UKS[iM1][j];
+                            Single[] UKS_E_L = Program.UKS[iP1][j];
+                            Single[] UKS_S_L = Program.UKS[i][jM1];
+                            Single[] UKS_ES_L = Program.UKS[iP1][jM1];
+                            Single[] UKS_WS_L = Program.UKS[iM1][jM1];
+                            Single[] VKS_S_L = Program.VKS[i][jM1];
+                            Single[] VKS_W_L = Program.VKS[iM1][j];
+                            Single[] WKS_S_L = Program.WKS[i][jM1];
+                            Single[] DPMNEW_S_L = Program.DPMNEW[i][jM1];
+
+                            Single[] UKS_EN_L = Program.UKS[iP1][jP1];
+                            Single[] UKS_WN_L = Program.UKS[iM1][jP1];
+                            Single[] WKS_N_L = Program.WK[i][jP1];
+                            Single[] UK_L = Program.UK[i][j];
+
+                            int KKART_LL = Program.KKART[i][j];
+                            int Vert_Index_LL = Program.VerticalIndex[i][j];
+                            float Ustern_terrain_helpterm = Program.UsternTerrainHelpterm[i][j];
+                            float Ustern_obstacles_helpterm = Program.UsternObstaclesHelpterm[i][j];
+                            //At a boundary of the prognostic domain?
+                            bool ADVDOM_S = (Program.ADVDOM[i][jM1] < 1) || (j == 2);
+                            bool ADVDOM_N = (Program.ADVDOM[i][jP1] < 1) || (j == Program.NJJ - 1);
+                            bool ADVDOM_W = (Program.ADVDOM[iM1][j] < 1) || (i == 2);
+                            bool ADVDOM_E = (Program.ADVDOM[iP1][j] < 1) || (i == Program.NII - 1);
+
+                            float CUTK_L = Program.CUTK[i][j];
+                            Single[] VEG_L = Program.VEG[i][j];
+                            Single COV_L = Program.COV[i][j];
+
+                            float Z0 = Program.Z0;
+                            if (Program.AdaptiveRoughnessMax < 0.01)
+                            {
+                                //Use GRAMM Roughness with terrain or Roughness from point 1,1 without terrain
+                                int IUstern = 1;
+                                int JUstern = 1;
+                                if ((Program.Topo == Consts.TerrainAvailable) && (Program.LandUseAvailable == true))
+                                {
+                                    double x = i * Program.DXK + Program.GralWest;
+                                    double y = j * Program.DYK + Program.GralSouth;
+                                    double xsi1 = x - Program.GrammWest;
+                                    double eta1 = y - Program.GrammSouth;
+                                    IUstern = Math.Clamp((int)(xsi1 / Program.DDX[1]) + 1, 1, Program.NX);
+                                    JUstern = Math.Clamp((int)(eta1 / Program.DDY[1]) + 1, 1, Program.NY);
+                                }
+                                Z0 = Program.Z0Gramm[IUstern][JUstern];
+                            }
+                            else
+                            {
+                                Z0 = Program.Z0Gral[i][j];
+                            }
+
+                            HOKART_KKART_V = Vector512.Create(Program.HOKART[KKART_LL]);
+
+                            int KSTART = 1;
+                            if (CUTK_L == 0) // building heigth == 0 m
+                            {
+                                KSTART = KKART_LL + 1;
+                            }
+
+                            int KKART_LL_P1 = KKART_LL + 1;
+
+                            int KEND = Vert_Index_LL + 1;
+                            bool end = false; // flag for the last loop 
+                            int k_real = 0;
+                            bool VegetationExists = VEG_L != null;
+
+                            for (int k = KSTART; k < KEND; k += Vector512<float>.Count)
+                            {
+                                // to compute the top levels - reduce k, remember k_real and set end to true
+                                k_real = k;
+                                if (k > KEND - Vector512<float>.Count)
+                                {
+                                    k = KEND - Vector512<float>.Count;
+                                    end = true;
+                                }
+                                int kM1 = k - 1;
+                                int kP1 = k + 1;
+
+                                WKS_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_L), (uint) k);
+                                VKS_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_L), (uint) k);
+                                UKS_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_L), (uint) k);
+                                DZK_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(Program.DZK), (uint) k);
+
+                                DXKDZK = Avx512F.Multiply(DXK_V, DZK_V);
+                                DYKDZK = Avx512F.Multiply(DYK_V, DZK_V);
+
+                                //turbulence modelling
+                                VK_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_L), (uint) k);
+                                zs = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(Program.HOKART), (uint) k) - Avx512F.FusedMultiplyAdd(DZK_V, Vect_05, HOKART_KKART_V);
+
+                                VIS = Vector512<float>.Zero;
+
+                                // Create Mask if KKART_LL is between k and k + Vector512<float>.Count
+                                bool mask_v_enable = false;
+                                if (KKART_LL_P1 >= k && KKART_LL_P1 < (k + Vector512<float>.Count))
+                                {
+                                    for (int ii = 0; ii < Mask.Length; ++ii)
+                                    {
+                                        if ((k + ii) > KKART_LL_P1)
+                                        {
+                                            Mask[ii] = 1;
+                                        }
+                                        else
+                                        {
+                                            Mask[ii] = 0;
+                                        }
+                                    }
+                                    Mask_V = Vector512.Create<float>(Mask);
+                                    mask_v_enable = true;
+                                }
+                                else
+                                {
+                                    Mask_V = Vector512<float>.One;
+                                }
+
+                                if ((k + Vector512<float>.Count) > KKART_LL_P1)
+                                {
+                                    //k-eps model
+                                    //float VIS = (float)Math.Sqrt(TURB_L[k]) * zs * Cmueh;
+
+                                    //mixing-length model
+                                    mixL = Vector512.Min<float>(Avx512F.Multiply(Vect_0071, zs), Vect_100);
+
+                                    //adapted mixing-leng th within vegetation layers
+                                    if (COV_L > 0)
+                                    {
+                                        mixL = Avx512F.Multiply(mixL, (Vect_1 - Avx512F.Multiply(Vect_099, Vector512.Create<float>(COV_L))));
+                                        //mixL = (float)Math.Min(0.071 * Math.Max(1 - Math.Min(2 * VEG_L[kM1], 1), 0.05) * zs, 100);
+                                    }
+
+                                    intern = Avx512F.Divide(Avx512F.Subtract(Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_L), (uint)kP1), Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_L), (uint)kM1)),
+                                    Avx512F.Multiply(Vect_2, DZK_V));
+                                    DUDZ = Avx512F.Multiply(intern, intern);
+
+                                    intern = Avx512F.Divide(Avx512F.Subtract(Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_L), (uint)kP1), Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_L), (uint)kM1)),
+                                    Avx512F.Multiply(Vect_2, DZK_V));
+                                    DVDZ = Avx512F.Multiply(intern, intern);
+                                    VIS = Vector512.Min<float>(Avx512F.Multiply(Avx512F.Multiply(mixL, mixL), Vector512.Sqrt<float>(Avx512F.Multiply(Vect_05, (DUDZ + DVDZ)))), Vect_15) * Mask_V;
+                                }
+
+                                //Diffusion terms
+                                DE = Avx512F.Divide(Avx512F.Multiply(Vector512.Max<float>(VIS, VISHMIN_V), DYKDZK), DXK_V);
+                                DW = DE;
+                                DS = Avx512F.Divide(Avx512F.Multiply(Vector512.Max<float>(VIS, VISHMIN_V), DXKDZK), DYK_V);
+                                DN = DS;
+                                DT = Avx512F.Divide(Avx512F.Multiply(Vector512.Max<float>(VIS, VISHMIN_V), AREAxy_V), DZK_V);
+                                DB = Vector512<float>.Zero;
+                                // To do : Set a Mask to take the right values
+                                if (mask_v_enable)
+                                {
+                                    DB = Avx512F.Multiply(DT, Mask_V);
+                                }
+                                else if (k > KKART_LL_P1) // otherwise k < KKART_LL_P1 and DB=0!
+                                {
+                                    DB = DT;
+                                }
+
+                                //BOUNDARY CONDITIONS FOR DIFFUSION TERMS
+                                if (ADVDOM_S)
+                                {
+                                    DS = Vector512<float>.Zero;
+                                }
+                                if (ADVDOM_N)
+                                {
+                                    DN = Vector512<float>.Zero;
+                                }
+                                if (ADVDOM_W)
+                                {
+                                    DW = Vector512<float>.Zero;
+                                }
+                                if (ADVDOM_E)
+                                {
+                                    DE = Vector512<float>.Zero;
+                                }
+
+                                //ADVECTION TERMS
+                                UKS_E_LV  = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_E_L), (uint) k);
+                                UKS_N_LV  = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_S_L), (uint) k);
+                                UKS_ES_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_ES_L), (uint) k);
+                                UKS_W_LV  = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_W_L), (uint) k);
+                                VKS_W_LV  = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_W_L), (uint) k);
+                                UKS_WS_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_WS_L), (uint) k);
+                                VKS_S_LV  = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_S_L), (uint) k);
+                                WKS_S_LV  = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_S_L), (uint) k);
+                                WKS_Sm_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_S_L), (uint) kM1);
+                                WKS_B_LV  = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_L), (uint) kM1);
+
+                                FE = Avx512F.Multiply(Avx512F.Multiply(Vect_025,
+                                     Avx512F.Add(Avx512F.Add(Avx512F.Add(UKS_V, UKS_E_LV), UKS_N_LV), UKS_ES_LV)), DYKDZK);
+                                FW = Avx512F.Multiply(Avx512F.Multiply(Vect_025,
+                                     Avx512F.Add(Avx512F.Add(Avx512F.Add(UKS_V, UKS_W_LV), UKS_N_LV), UKS_WS_LV)), DYKDZK);
+                                FS = Avx512F.Multiply(VKS_S_LV, DXKDZK);
+                                FN = Avx512F.Multiply(VKS_V, DXKDZK);
+                                FT = Avx512F.Multiply(Avx512F.Multiply(Vect_025, (WKS_S_LV + WKS_V + Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_S_L), (uint) kP1) + 
+                                     Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_L), (uint) kP1))), AREAxy_V);
+                                FB = Vector512<float>.Zero;
+
+                                if (mask_v_enable)
+                                {
+                                    FB = Avx512F.Multiply(Avx512F.Multiply(Vect_025, 
+                                        Avx512F.Add(Avx512F.Add(Avx512F.Add(WKS_S_LV, WKS_V), WKS_Sm_LV), WKS_B_LV)),
+                                        AREAxy_V) * Mask_V;
+                                }
+                                else if (k > KKART_LL_P1) // otherwise k < KKART_LL_P1 and FB=0!
+                                {
+                                    FB = Avx512F.Multiply(Avx512F.Multiply(Vect_025, 
+                                        Avx512F.Add(Avx512F.Add(Avx512F.Add(WKS_S_LV, WKS_V), WKS_Sm_LV), WKS_B_LV)),
+                                        AREAxy_V);
+                                }
+
+                                //PECLET NUMBERS
+                                DE = Vector512.Max<float>(DE, Vect_0001);
+                                DB = Vector512.Max<float>(DB, Vect_0001);
+                                DW = Vector512.Max<float>(DW, Vect_0001);
+                                DS = Vector512.Max<float>(DS, Vect_0001);
+                                DN = Vector512.Max<float>(DN, Vect_0001);
+                                DT = Vector512.Max<float>(DT, Vect_0001);
+
+                                PE = Vector512.Abs<float>(FE / DE);
+                                PB = Vector512.Abs<float>(FB / DB);
+                                PW = Vector512.Abs<float>(FW / DW);
+                                PS = Vector512.Abs<float>(FS / DS);
+                                PN = Vector512.Abs<float>(FN / DN);
+                                PT = Vector512.Abs<float>(FT / DT);
+
+                                //POWER LAW ADVECTION SCHEME
+                                intern = Vect_1 - Vect_01 * PT;
+                                BIM = Avx512F.FusedMultiplyAdd(DT, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(-FT, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PB;
+                                CIM = Avx512F.FusedMultiplyAdd(DB, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                                Vector512.Max<float>(FB, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PE;
+                                AE1 = Avx512F.FusedMultiplyAdd(DE, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(-FE, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PW;
+                                AW1 = Avx512F.FusedMultiplyAdd(DW, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(FW, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PS;
+                                AS1 = Avx512F.FusedMultiplyAdd(DS, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(FS, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PN;
+                                AN1 = Avx512F.FusedMultiplyAdd(DN, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(-FN, Vect_0));
+
+                                //UPWIND SCHEME
+                                /*
+                                    double BIM = DT + Program.fl_max(-FT, 0);
+                                    double CIM = DB + Program.fl_max(FB, 0);
+                                    double AE1 = DE + Program.fl_max(-FE, 0);
+                                    double AW1 = DW + Program.fl_max(FW, 0);
+                                    double AS1 = DS + Program.fl_max(FS, 0);
+                                    double AN1 = DN + Program.fl_max(-FN, 0);
+                                 */
+
+                                AP0_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(PrognosticFlowfield.AP0), (uint) k);
+                                AIM = Avx512F.Add(Avx512F.Add(Avx512F.Add(Avx512F.Add(Avx512F.Add(Avx512F.Add(BIM, CIM), AW1), AS1), AE1), AN1), AP0_V);
+
+                                //SOURCE TERMS
+                                DDPY = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(DPMNEW_S_L), (uint) k) - Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(DPMNEW_L), (uint) k);
+                                VK_N_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_N_L), (uint) k);
+                                VK_S_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_S_L), (uint) k);
+
+                                if (VegetationExists)
+                                {
+                                    intern2 = Avx512F.Multiply(Vect_05, (VKS_W_LV + VKS_V));
+                                    intern = Avx512F.Multiply(Vect_05, (UKS_W_LV + UKS_V));
+                                    windhilf = Vector512.Max<float>(Vector512.Sqrt<float>(Avx512F.Multiply(intern, intern) + Avx512F.Multiply(intern2, intern2)), Vect_001);
+                                    DIMV = Avx512F.FusedMultiplyAdd(AW1, Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_W_L), (uint) k),
+                                           AS1 * VK_S_LV) +
+                                           Avx512F.FusedMultiplyAdd(AE1, Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_E_L), (uint) k),
+                                           AN1 * VK_N_LV) +
+                                           AP0_V * Vect_05 * (VKS_S_LV + VKS_V) + DDPY * DXKDZK +
+                                           (Avx512F.Multiply(Coriolis, Avx512F.Subtract(VG_V, VK_LV)) -
+                                           Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VEG_L), (uint) kM1) * VK_LV * windhilf) * AREAxy_V * DZK_V;
+                                }
+                                else
+                                {
+                                    DIMV = AW1 * Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_W_L), (uint) k) +
+                                           AS1 * VK_S_LV +
+                                           AE1 * Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_E_L), (uint) k) +
+                                           AN1 * VK_N_LV +
+                                           AP0_V * Vect_05 * (VKS_S_LV + VKS_V) + DDPY * DXKDZK +
+                                           Avx512F.Multiply(Avx512F.Multiply(Avx512F.Multiply(Coriolis, Avx512F.Subtract(VG_V, VK_LV)), AREAxy_V), DZK_V);
+                                }
+                                //BOUNDARY CONDITION AT SURFACES (OBSTACLES AND TERRAIN)
+                                if ((k <= KKART_LL_P1) && ((k + Vector512<float>.Count) > KKART_LL_P1))
+                                {
+                                    Mask2.Clear();
+                                    //Array.Clear(Mask2, 0, Mask2.Length);
+                                    int ii = KKART_LL_P1 - k;   // 0 to SIMD - 1
+                                    Mask2[ii] = 1;              // Set the mask2 at SIMD position k == KKART_LL_P1 to 1
+                                    intern = Vect_05 * (UKS_W_LV + UKS_V);
+                                    intern2 = Vect_05 * (VKS_W_LV + VKS_V);
+                                    windhilf = Vector512.Max<float>(Vector512.Sqrt<float>(Avx512F.Multiply(intern, intern) + Avx512F.Multiply(intern2, intern2)), Vect_01);
+
+                                    if (CUTK_L < 1) // building heigth < 1 m
+                                    {
+                                        //above terrain
+                                        float Ustern_Buildings = Ustern_terrain_helpterm * windhilf[ii];
+                                        if (Z0 >= DZK_V[ii] * 0.1F)
+                                        {
+                                            int ind = k + ii + 1;
+                                            Ustern_Buildings = Ustern_terrain_helpterm * MathF.Sqrt(Program.Pow2(0.5F * ((UKS_W_L[ind]) + UKS_L[ind])) + Program.Pow2(0.5F * ((VKS_W_L[ind]) + VKS_L[ind])));
+                                        }
+                                        Vector512<float>  Ustern_Buildings_V = Vector512.Create(Ustern_Buildings * Ustern_Buildings);
+                                        DIMV -= VK_LV / windhilf * Ustern_Buildings_V * AREAxy_V * Vector512.Create<float>(Mask2);
+                                    }
+                                    else
+                                    {
+                                        //above a building
+                                        float Ustern_Buildings = Ustern_obstacles_helpterm * windhilf[ii];
+                                        Vector512<float>  Ustern_Buildings_V = Vector512.Create(Ustern_Buildings * Ustern_Buildings);
+                                        DIMV -= VK_LV / windhilf * Ustern_Buildings_V * AREAxy_V * Vector512.Create<float>(Mask2);
+                                    }
+                                }
+
+                                //additional terms of the eddy-viscosity model
+                                if (k > KKART_LL_P1)
+                                {
+                                    DVDYN = (VK_N_LV - VK_LV) * DXKDZK;
+                                    DVDYS = (VK_LV - VK_S_LV) * DXKDZK;
+                                    DUDYE = (Vect_05 * (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_EN_L), (uint) k) + UKS_E_LV) - Vect_05 * (UKS_E_LV + UKS_ES_LV)) * DXKDZK;
+                                    DUDYW = (Vect_05 * (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_WN_L), (uint) k) + UKS_W_LV) - Vect_05 * (UKS_W_LV + UKS_WS_LV)) * DXKDZK;
+                                    DWDYT = (Vect_05 * (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_N_L), (uint) k) + WKS_V) - Vect_05 * (WKS_V + WKS_S_LV)) * AREAxy_V;
+                                    DWDYB = (Vect_05 * (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_N_L), (uint) kM1) + WKS_B_LV) - Vect_05 * (WKS_B_LV + WKS_S_LV)) * AREAxy_V;
+
+                                    DIMV += VIS / DXK_V * (DUDYE - DUDYW + DVDYN - DVDYS + DWDYT - DWDYB) * Mask_V;
+                                }
+
+                                //RECURRENCE FORMULA
+                                int kint_s = 0;
+                                if (end) // restore original indices 
+                                {
+                                    kint_s = k_real - k;
+                                    k_real -= kint_s;
+                                }
+
+                                Vector512.StoreUnsafe<float>(AIM, ref AIM_A[0]);
+                                Vector512.StoreUnsafe<float>(BIM, ref BIM_A[0]);
+                                Vector512.StoreUnsafe<float>(CIM, ref CIM_A[0]);
+                                Vector512.StoreUnsafe<float>(DIMV, ref DIMV_A[0]);
+                           
+                                for (int kint = kint_s; kint < AIM_A.Length; ++kint) // loop over all SIMD values
+                                {
+                                    int index_i = k_real + kint;
+
+                                    if (index_i < KEND)
+                                    {
+                                        if (index_i > KKART_LL_P1)
+                                        {
+                                            float TERMP = 1 / (AIM_A[kint] - CIM_A[kint] * PIMV[index_i - 1]);
+                                            PIMV[index_i] = BIM_A[kint] * TERMP;
+                                            QIMV[index_i] = (DIMV_A[kint] + CIM_A[kint] * QIMV[index_i - 1]) * TERMP;
+                                        }
+                                        else
+                                        {
+                                            float TERMP = 1 / AIM_A[kint];
+                                            PIMV[index_i] = BIM_A[kint] * TERMP;
+                                            QIMV[index_i] = DIMV_A[kint] * TERMP;
+                                        }
+                                    }
+                                }
+
+                                if (end)
+                                {
+                                    k = KEND + 1;
+                                }
+
+                            } // loop over all k
+
+                            //OBTAIN NEW V-COMPONENTS
+                            int KKARTm_LL = Math.Max(KKART_LL, Program.KKART[i][j - 1]);
+                            lock (VK_L)
+                            {
+                                for (int k = Vert_Index_LL; k >= KSTART; --k)
+                                {
+                                    if (KKARTm_LL < k)
+                                    {
+                                        VK_L[k] += relax * (PIMV[k] * VK_L[k + 1] + QIMV[k] - VK_L[k]);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+    }
+}

--- a/src/W-prognostic-microscale_1_Vec512.cs
+++ b/src/W-prognostic-microscale_1_Vec512.cs
@@ -1,7 +1,7 @@
 #region Copyright
 ///<remarks>
 /// <Graz Lagrangian Particle Dispersion Model>
-/// Copyright (C) [2019]  [Dietmar Oettl, Markus Kuntner]
+/// Copyright (C) [2024] [Markus Kuntner] Predecessor: [2019]  [Dietmar Oettl, Markus Kuntner]
 /// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
 /// the Free Software Foundation version 3 of the License
 /// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/W-prognostic-microscale_1_Vec512.cs
+++ b/src/W-prognostic-microscale_1_Vec512.cs
@@ -1,0 +1,450 @@
+#region Copyright
+///<remarks>
+/// <Graz Lagrangian Particle Dispersion Model>
+/// Copyright (C) [2019]  [Dietmar Oettl, Markus Kuntner]
+/// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation version 3 of the License
+/// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+/// You should have received a copy of the GNU General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+///</remarks>
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Collections.Concurrent;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.InteropServices;
+
+namespace GRAL_2001
+{
+    public class W_PrognosticMicroscaleV1_Vec512
+    {
+        static readonly Vector512<float> Vect_0 = Vector512<float>.Zero;
+        static readonly Vector512<float> Vect_1 = Vector512<float>.One;
+        static readonly Vector512<float> Vect_01 = Vector512.Create(0.1F);
+        static readonly Vector512<float> Vect_025 = Vector512.Create(0.25F);
+        static readonly Vector512<float> Vect_05 = Vector512.Create(0.5F);
+        static readonly Vector512<float> Vect_099 = Vector512.Create(0.99F);
+        static readonly Vector512<float> Vect_0071 = Vector512.Create(0.071F);
+        static readonly Vector512<float> Vect_2 = Vector512.Create(2F);
+        static readonly Vector512<float> Vect_001 = Vector512.Create(0.01F);
+        static readonly Vector512<float> Vect_15 = Vector512.Create(15F);
+        static readonly Vector512<float> Vect_100 = Vector512.Create(100F);
+        static readonly Vector512<float> Vect_0001 = Vector512.Create(0.0001F);
+     
+        /// <summary>
+        /// Momentum equations for the w wind component - algebraic mixing lenght model
+        /// </summary>
+        /// <param name="IS">ADI direction for x cells</param>
+        /// <param name="JS">ADI direction for y cells</param>
+        /// <param name="Cmueh">Constant</param>
+        /// <param name="VISHMIN">Minimum horizontal turbulent exchange coefficients </param>
+        /// <param name="AREAxy">Area of a flow field cell</param>
+        /// <param name="building_Z0">Roughness of buildings</param>
+        /// <param name="relax">Relaxation factor</param>
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        [SkipLocalsInit]
+        public static void Calculate(int IS, int JS, float Cmueh, float VISHMIN, float AREAxy, float relax)
+        {
+            Vector512<float> DXK_V = Vector512.Create(Program.DXK);
+            Vector512<float> DYK_V = Vector512.Create(Program.DYK);
+            Vector512<float> VISHMIN_V = Vector512.Create(VISHMIN);
+            Vector512<float> AREAxy_V = Vector512.Create(AREAxy);
+            
+            int maxTasks = Math.Max(1, Program.IPROC + Math.Abs(Environment.TickCount % 8));
+            int minL = Math.Min(64, Program.NII - 4); // Avoid too large slices due to perf issues
+            Parallel.ForEach(Partitioner.Create(2, Program.NII, Math.Min(Math.Max(4, (Program.NII / maxTasks)), minL)), Program.pOptions, range =>
+            //Parallel.For(2, Program.NII, Program.pOptions, i1 =>
+            {
+                Span<float> PIMW = stackalloc float[Program.KADVMAX + 1];
+                Span<float> QIMW = stackalloc float[Program.KADVMAX + 1];
+                Span<float> Mask = stackalloc float[Vector512<float>.Count];
+                Span<float> AIM_A = stackalloc float[Vector512<float>.Count];
+                Span<float> BIM_A = stackalloc float[Vector512<float>.Count];
+                Span<float> CIM_A = stackalloc float[Vector512<float>.Count];
+                Span<float> DIMW_A = stackalloc float[Vector512<float>.Count];
+
+                Vector512<float> DUDZE, DUDZW, DVDZN, DVDZS, DWDZT, DWDZB;
+                Vector512<float> DE, DW, DS, DN, DT, DB;
+                Vector512<float> FE, FW, FS, FN, FT, FB;
+                Vector512<float> PE, PW, PS, PN, PT, PB;
+                Vector512<float> BIM, CIM, AE1, AW1, AS1, AN1, AIM;
+                Vector512<float> DIMW, windhilf;
+                Vector512<float> DDPZ;
+
+                Vector512<float> UKS_W_LV, UKS_WB_LV;
+                Vector512<float> VKS_S_LV, VKS_SB_LV;
+
+                Vector512<float> WKS_V, VKS_V, UKS_V, DZK_V;
+                Vector512<float> DXKDZK, DYKDZK, AP0_V, intern, intern2;
+
+                Vector512<float> VIS, zs, mixL;
+                Vector512<float> HOKART_KKART_V;
+
+                Vector512<float> Mask_V = Vector512<float>.Zero;
+                Vector512<float> DUDZ, DVDZ;
+
+                Vector512<float> UKS_M_V, VKS_M_V, WK_LV;
+            
+                for (int i1 = range.Item1; i1 < range.Item2; i1++)
+                {
+                    int i = i1;
+                    if (IS == -1)
+                    {
+                        i = Program.NII - i1 + 1;
+                    }
+
+                    for (int j1 = 2; j1 < Program.NJJ; ++j1)
+                    {
+                        int j = j1;
+                        if (JS == -1)
+                        {
+                            j = Program.NJJ - j1 + 1;
+                        }
+
+                        if (Program.ADVDOM[i][j] == 1)
+                        {
+                            //inside a prognostic sub domain
+                            int jM1 = j - 1;
+                            int jP1 = j + 1;
+                            int iM1 = i - 1;
+                            int iP1 = i + 1;
+
+                            Single[] WK_L = Program.WK[i][j];
+                            Single[] WK_W_L = Program.WK[iM1][j];
+                            Single[] WK_E_L = Program.WK[iP1][j];
+                            Single[] WK_S_L = Program.WK[i][jM1];
+                            Single[] WK_N_L = Program.WK[i][jP1];
+                            Single[] UKS_L = Program.UKS[i][j];
+                            Single[] VKS_L = Program.VKS[i][j];
+                            Single[] WKS_L = Program.WKS[i][j];
+                            Single[] DPMNEW_L = Program.DPMNEW[i][j];
+                            Single[] VK_W_L = Program.VK[iM1][j];
+                            Single[] VK_E_L = Program.VK[iP1][j];
+                            Single[] VK_S_L = Program.VK[i][jM1];
+                            Single[] VK_N_L = Program.VK[i][jP1];
+                            Single[] UKS_W_L = Program.UKS[iM1][j];
+                            Single[] UKS_E_L = Program.UKS[iP1][j];
+                            Single[] VKS_S_L = Program.VKS[i][jM1];
+                            Single[] VKS_N_L = Program.VKS[i][jP1];
+
+                            Single[] UK_L = Program.UK[i][j];
+                            Single[] VK_L = Program.VK[i][j];
+
+                            int KKART_LL = Program.KKART[i][j];
+                            int Vert_Index_LL = Program.VerticalIndex[i][j];
+                            float Ustern_terrain_helpterm = Program.UsternTerrainHelpterm[i][j];
+                            float Ustern_obstacles_helpterm = Program.UsternObstaclesHelpterm[i][j];
+                            //At a boundary of the prognostic domain?
+                            bool ADVDOM_S = (Program.ADVDOM[i][jM1] < 1) || (j == 2);
+                            bool ADVDOM_N = (Program.ADVDOM[i][jP1] < 1) || (j == Program.NJJ - 1);
+                            bool ADVDOM_W = (Program.ADVDOM[iM1][j] < 1) || (i == 2);
+                            bool ADVDOM_E = (Program.ADVDOM[iP1][j] < 1) || (i == Program.NII - 1);
+
+                            Single[] VEG_L = Program.VEG[i][j];
+                            Single COV_L = Program.COV[i][j];
+
+                            HOKART_KKART_V = Vector512.Create(Program.HOKART[KKART_LL]);
+
+                            int KSTART = 1;
+                            if (Program.CUTK[i][j] == 0)
+                            {
+                                KSTART = KKART_LL + 1;
+                            }
+
+                            int KKART_LL_P1 = KKART_LL + 1;
+
+                            int KEND = Vert_Index_LL + 1;
+                            bool end = false; // flag for the last loop 
+                            int k_real = 0;
+                            bool VegetationExists = VEG_L != null;
+
+                            for (int k = KSTART; k < KEND; k += Vector512<float>.Count)
+                            {
+                                // to compute the top levels - reduce k, remember k_real and set end to true
+                                k_real = k;
+                                if (k > KEND - Vector512<float>.Count)
+                                {
+                                    k = KEND - Vector512<float>.Count;
+                                    end = true;
+                                }
+                                int kM1 = k - 1;
+                                int kP1 = k + 1;
+
+                                WKS_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_L), (uint) k);
+                                VKS_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_L), (uint) k);
+                                UKS_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_L), (uint) k);
+                                DZK_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(Program.DZK), (uint) k);
+
+                                DXKDZK = Avx512F.Multiply(DXK_V, DZK_V);
+                                DYKDZK = Avx512F.Multiply(DYK_V, DZK_V);
+
+                                UKS_M_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_L), (uint) kM1);
+                                VKS_M_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_L), (uint) kM1);
+
+                                //turbulence modelling
+                                zs = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(Program.HOKART), (uint) k) - Avx512F.FusedMultiplyAdd(DZK_V, Vect_05, HOKART_KKART_V);
+
+                                VIS = Vector512<float>.Zero;
+
+                                // Create Mask if KKART_LL is between k and k + SIMD
+                                bool mask_v_enable = false;
+                                if (KKART_LL_P1 >= k && KKART_LL_P1 < (k + Vector512<float>.Count))
+                                {
+                                    for (int ii = 0; ii < Mask.Length; ++ii)
+                                    {
+                                        if ((k + ii) > KKART_LL_P1)
+                                        {
+                                            Mask[ii] = 1;
+                                        }
+                                        else
+                                        {
+                                            Mask[ii] = 0;
+                                        }
+                                    }
+                                    Mask_V = Vector512.Create<float>(Mask);
+                                    mask_v_enable = true;
+                                }
+                                else
+                                {
+                                    Mask_V = Vector512<float>.One;
+                                }
+
+                                if ((k + Vector512<float>.Count) > KKART_LL_P1)
+                                {
+                                    //k-eps model
+                                    //float VIS = (float)Math.Sqrt(TURB_L[k]) * zs * Cmueh;
+
+                                    //mixing-length model
+                                    mixL = Vector512.Min<float>(Avx512F.Multiply(Vect_0071, zs), Vect_100);
+
+                                    //adapted mixing-leng th within vegetation layers
+                                    if (COV_L > 0)
+                                    {
+                                        mixL = Avx512F.Multiply(mixL, (Vect_1 - Avx512F.Multiply(Vect_099, Vector512.Create<float>(COV_L))));
+                                        //mixL = (float)Math.Min(0.071 * Math.Max(1 - Math.Min(2 * VEG_L[kM1], 1), 0.05) * zs, 100);
+                                    }
+
+                                    intern = Avx512F.Divide(Avx512F.Subtract(Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_L), (uint) kP1), Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UK_L), (uint) kM1)),
+                                    Avx512F.Multiply(Vect_2, DZK_V));
+                                    DUDZ = Avx512F.Multiply(intern, intern);
+
+                                    intern = Avx512F.Divide(Avx512F.Subtract(Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_L), (uint) kP1), Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VK_L), (uint) kM1)),
+                                    Avx512F.Multiply(Vect_2, DZK_V));
+                                    DVDZ = Avx512F.Multiply(intern, intern);
+
+                                    VIS = Vector512.Min<float>(Avx512F.Multiply(Avx512F.Multiply(mixL, mixL), Vector512.Sqrt<float>(Avx512F.Multiply(Vect_05, (DUDZ + DVDZ)))), Vect_15) * Mask_V;
+                                }
+
+                                //Diffusion terms
+                                DE = Avx512F.Divide(Avx512F.Multiply(Vector512.Max<float>(VIS, VISHMIN_V), DYKDZK), DXK_V);
+                                DW = DE;
+                                DS = Avx512F.Divide(Avx512F.Multiply(Vector512.Max<float>(VIS, VISHMIN_V),DXKDZK), DYK_V);
+                                DN = DS;
+                                DT = Avx512F.Divide(Avx512F.Multiply(Vector512.Max<float>(VIS, VISHMIN_V), AREAxy_V), DZK_V);
+                                DB = Vector512<float>.Zero;
+
+                                if (mask_v_enable)
+                                {
+                                    DB = DT * Mask_V;
+                                }
+                                else if (k > KKART_LL_P1) // otherwise k < KKART_LL_P1 and DB=0!
+                                {
+                                    DB = DT;
+                                }
+
+                                //BOUNDARY CONDITIONS FOR DIFFUSION TERMS
+                                if (ADVDOM_S)
+                                {
+                                    DS = Vector512<float>.Zero;
+                                }
+                                if (ADVDOM_N)
+                                {
+                                    DN = Vector512<float>.Zero;
+                                }
+                                if (ADVDOM_W)
+                                {
+                                    DW = Vector512<float>.Zero;
+                                }
+                                if (ADVDOM_E)
+                                {
+                                    DE = Vector512<float>.Zero;
+                                }
+
+                                //ADVECTION TERMS
+                                UKS_W_LV  = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_W_L), (uint) k);
+                                UKS_WB_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_W_L), (uint) kM1);
+                                VKS_S_LV  = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_S_L), (uint) k);
+                                VKS_SB_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_S_L), (uint) kM1);
+
+                                FE = Avx512F.Multiply(Avx512F.Multiply(Vect_025, (UKS_V + Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_E_L), (uint) k) + 
+                                     UKS_M_V + Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_E_L), (uint) kM1))), DYKDZK);
+                                FW = Avx512F.Multiply(Avx512F.Multiply(Vect_025,
+                                     Avx512F.Add(Avx512F.Add(Avx512F.Add(UKS_V, UKS_W_LV), UKS_M_V), UKS_WB_LV)), DYKDZK);
+                                FS = Avx512F.Multiply(Avx512F.Multiply(Vect_025,
+                                     Avx512F.Add(Avx512F.Add(Avx512F.Add(VKS_V, VKS_S_LV), VKS_M_V), VKS_SB_LV)), DXKDZK);
+                                FN = Avx512F.Multiply(Avx512F.Multiply(Vect_025, (VKS_V + Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_N_L), (uint) k) + 
+                                     VKS_M_V + Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_N_L), (uint) kM1))), DXKDZK);
+                                FT = Avx512F.Multiply(WKS_V, AREAxy_V);
+                                FB = Vector512<float>.Zero;
+
+                                if (mask_v_enable)
+                                {
+                                    FB = Avx512F.Multiply(Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_L), (uint) kM1),
+                                         AREAxy_V) * Mask_V;
+                                }
+                                else if (k > KKART_LL_P1) // otherwise k < KKART_LL_P1 and FB=0!
+                                {
+                                    FB = Avx512F.Multiply(Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_L), (uint) kM1),
+                                        AREAxy_V);
+                                }
+
+                                //PECLET NUMBERS
+                                DE = Vector512.Max<float>(DE, Vect_0001);
+                                DB = Vector512.Max<float>(DB, Vect_0001);
+                                DW = Vector512.Max<float>(DW, Vect_0001);
+                                DS = Vector512.Max<float>(DS, Vect_0001);
+                                DN = Vector512.Max<float>(DN, Vect_0001);
+                                DT = Vector512.Max<float>(DT, Vect_0001);
+
+                                PE = Vector512.Abs<float>(FE / DE);
+                                PB = Vector512.Abs<float>(FB / DB);
+                                PW = Vector512.Abs<float>(FW / DW);
+                                PS = Vector512.Abs<float>(FS / DS);
+                                PN = Vector512.Abs<float>(FN / DN);
+                                PT = Vector512.Abs<float>(FT / DT);
+
+                                //POWER LAW ADVECTION SCHEME
+                                intern = Vect_1 - Vect_01 * PT;
+                                BIM = Avx512F.FusedMultiplyAdd(DT, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(-FT, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PB;
+                                CIM = Avx512F.FusedMultiplyAdd(DB, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(FB, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PE;
+                                AE1 = Avx512F.FusedMultiplyAdd(DE, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(-FE, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PW;
+                                AW1 = Avx512F.FusedMultiplyAdd(DW, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(FW, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PS;
+                                AS1 = Avx512F.FusedMultiplyAdd(DS, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(FS, Vect_0));
+
+                                intern = Vect_1 - Vect_01 * PN;
+                                AN1 = Avx512F.FusedMultiplyAdd(DN, Vector512.Max<float>(Vect_0, Avx512F.Multiply(intern, Avx512F.Multiply(Avx512F.Multiply(intern, intern), Avx512F.Multiply(intern, intern)))),
+                                                               Vector512.Max<float>(-FN, Vect_0));
+
+                                //UPWIND SCHEME
+                                /*
+                                    double BIM = DT + Program.fl_max(-FT, 0);
+                                    double CIM = DB + Program.fl_max(FB, 0);
+                                    double AE1 = DE + Program.fl_max(-FE, 0);
+                                    double AW1 = DW + Program.fl_max(FW, 0);
+                                    double AS1 = DS + Program.fl_max(FS, 0);
+                                    double AN1 = DN + Program.fl_max(-FN, 0);
+                                 */
+
+                                AP0_V = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(PrognosticFlowfield.AP0), (uint) k);
+                                AIM = Avx512F.Add(Avx512F.Add(Avx512F.Add(Avx512F.Add(Avx512F.Add(Avx512F.Add(BIM, CIM), AW1), AS1), AE1), AN1), AP0_V);
+
+                                //SOURCE TERMS
+                                DDPZ = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(DPMNEW_L), (uint) kM1) - Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(DPMNEW_L), (uint) k);
+                                WK_LV = Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WK_L), (uint) k);
+
+                                if (VegetationExists)
+                                {
+                                    intern2 = Avx512F.Multiply(Vect_05, (VKS_S_LV + VKS_V));
+                                    intern = Avx512F.Multiply(Vect_05, (UKS_W_LV + UKS_V));
+                                    windhilf = Vector512.Max<float>(Vector512.Sqrt<float>(Avx512F.Multiply(intern, intern) + Avx512F.Multiply(intern2, intern2)), Vect_001);
+                                    DIMW = Avx512F.FusedMultiplyAdd(AW1, Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WK_W_L), (uint) k),
+                                           AS1 * Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WK_S_L), (uint) k)) +
+                                           Avx512F.FusedMultiplyAdd(AE1, Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WK_E_L), (uint) k),
+                                           AN1 * Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WK_N_L), (uint) k)) +
+                                           AP0_V * Vect_05 * (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_L), (uint) kM1) + WKS_V) +
+                                           DDPZ * AREAxy_V -
+                                           Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VEG_L), (uint) kM1) * WK_LV * windhilf * AREAxy_V * DZK_V;
+                                }
+                                else
+                                {
+                                    DIMW = Avx512F.FusedMultiplyAdd(AW1, Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WK_W_L), (uint) k),
+                                       AS1 * Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WK_S_L), (uint) k)) +
+                                       Avx512F.FusedMultiplyAdd(AE1, Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WK_E_L), (uint) k),
+                                       AN1 * Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WK_N_L), (uint) k)) +
+                                       Avx512F.Multiply(AP0_V, Vect_05) * (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WKS_L), (uint) kM1) + WKS_V) +
+                                       Avx512F.Multiply(DDPZ, AREAxy_V);
+                                }
+
+                                //additional terms of the eddy-viscosity model
+                                if (k > KKART_LL_P1)
+                                {
+                                    DUDZE = Avx512F.Multiply(Avx512F.Multiply(Vect_05, (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_L), (uint) kP1) + UKS_V) - Avx512F.Multiply(Vect_05, (UKS_V + UKS_M_V))), DYKDZK);
+                                    DUDZW = Avx512F.Multiply(Avx512F.Multiply(Vect_05, (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(UKS_W_L), (uint) kP1) + UKS_W_LV) - Avx512F.Multiply(Vect_05, (UKS_W_LV + UKS_WB_LV))), DYKDZK);
+                                    DVDZN = Avx512F.Multiply(Avx512F.Multiply(Vect_05, (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_L), (uint)kP1) + VKS_V) - Avx512F.Multiply(Vect_05, (VKS_V + VKS_M_V))), DXKDZK);
+                                    DVDZS = Avx512F.Multiply(Avx512F.Multiply(Vect_05, (Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(VKS_S_L), (uint)kP1) + VKS_S_LV) - Avx512F.Multiply(Vect_05, (VKS_S_LV + VKS_SB_LV))), DXKDZK);
+                                    DWDZT = Avx512F.Multiply((Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WK_L), (uint) kP1) - WK_LV), AREAxy_V);
+                                    DWDZB = Avx512F.Multiply((WK_LV - Vector512.LoadUnsafe<float>(ref MemoryMarshal.GetArrayDataReference(WK_L), (uint) kM1)), AREAxy_V);
+
+                                    DIMW = Avx512F.Add(DIMW, Avx512F.Multiply(Avx512F.Multiply(Avx512F.Divide(VIS, DZK_V), (DUDZE - DUDZW + DVDZN - DVDZS + DWDZT - DWDZB)), Mask_V));
+                                }
+
+                                //RECURRENCE FORMULA
+                                int kint_s = 0;
+                                if (end) // restore original indices 
+                                {
+                                    kint_s = k_real - k;
+                                    k_real -= kint_s;
+                                }
+
+                                Vector512.StoreUnsafe<float>(AIM, ref AIM_A[0]);
+                                Vector512.StoreUnsafe<float>(BIM, ref BIM_A[0]);
+                                Vector512.StoreUnsafe<float>(CIM, ref CIM_A[0]);
+                                Vector512.StoreUnsafe<float>(DIMW, ref DIMW_A[0]);
+
+                                for (int kint = kint_s; kint < AIM_A.Length; ++kint) // loop over all SIMD values
+                                {
+                                    int index_i = k_real + kint;
+
+                                    if (index_i < KEND)
+                                    {
+                                        if (index_i > KKART_LL_P1)
+                                        {
+                                            float TERMP = 1 / (AIM_A[kint] - CIM_A[kint] * PIMW[index_i - 1]);
+                                            PIMW[index_i] = BIM_A[kint] * TERMP;
+                                            QIMW[index_i] = (DIMW_A[kint] + CIM_A[kint] * QIMW[index_i - 1]) * TERMP;
+                                        }
+                                        else
+                                        {
+                                            float TERMP = 1 / AIM_A[kint];
+                                            PIMW[index_i] = BIM_A[kint] * TERMP;
+                                            QIMW[index_i] = DIMW_A[kint] * TERMP;
+                                        }
+                                    }
+                                }
+
+                                if (end)
+                                {
+                                    k = KEND + 1;
+                                }
+
+                            } // loop over all k
+
+                            //OBTAIN NEW W-COMPONENTS
+                            for (int k = Vert_Index_LL; k >= KSTART; --k)
+                            {
+                                WK_L[k] += relax * (PIMW[k] * WK_L[k + 1] + QIMW[k] - WK_L[k]);
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/Write3DConcentrations.cs
+++ b/src/Write3DConcentrations.cs
@@ -143,34 +143,34 @@ namespace GRAL_2001
                             //h = string.Empty;
                             for (int i = 1; i <= Program.NII + 1; i++)
                             {
-                                if (i > 1 && j > 1 && i < (Program.NII - 2) && (j < Program.NJJ - 2)) // low pass filter the 3D concentration
-                                {
-                                    if (Program.ConzSsum[i][j][k] > 0) // concentration != 0?
-                                    {
-                                        double weighting_factor = 0;
-                                        val = 0;
+                                // if (i > 1 && j > 1 && i < (Program.NII - 2) && (j < Program.NJJ - 2)) // low pass filter the 3D concentration
+                                // {
+                                //     if (Program.ConzSsum[i][j][k] > 0) // concentration != 0?
+                                //     {
+                                //         double weighting_factor = 0;
+                                //         val = 0;
 
-                                        LowPass(ref val, ref weighting_factor, k, i, j, 1.0);
-                                        if (k > 1)
-                                        {
-                                            LowPass(ref val, ref weighting_factor, k - 1, i, j, 0.3);
-                                        }
-                                        if (k < Program.NKK_Transient - 2)
-                                        {
-                                            LowPass(ref val, ref weighting_factor, k + 1, i, j, 0.3);
-                                        }
+                                //         LowPass(ref val, ref weighting_factor, k, i, j, 1.0);
+                                //         if (k > 1)
+                                //         {
+                                //             LowPass(ref val, ref weighting_factor, k - 1, i, j, 0.3);
+                                //         }
+                                //         if (k < Program.NKK_Transient - 2)
+                                //         {
+                                //             LowPass(ref val, ref weighting_factor, k + 1, i, j, 0.3);
+                                //         }
 
-                                        val = val / weighting_factor / Program.ConzSumCounter;
-                                    }
-                                    else // concentration == 0
-                                    {
-                                        val = 0;
-                                    }
-                                }
-                                else // border cells
-                                {
-                                    val = Program.ConzSsum[i][j][k] / Program.ConzSumCounter;
-                                }
+                                //         val = val / weighting_factor / Program.ConzSumCounter;
+                                //     }
+                                //     else // concentration == 0
+                                //     {
+                                //         val = 0;
+                                //     }
+                                // }
+                                // else // border cells
+                                // {
+                                val = Program.ConzSsum[i][j][k] / Program.ConzSumCounter;
+                                //}
 
                                 SB.Append(val.ToString("e2", ic));
                                 SB.Append("\t");

--- a/src/Zeitschleife_nonsteadystate.cs
+++ b/src/Zeitschleife_nonsteadystate.cs
@@ -158,8 +158,6 @@ namespace GRAL_2001
             int TransientGridY = 1;
             int TransientGridZ = 1;
 
-            TransientConcentration trans_conz = new TransientConcentration();
-
             /*
              *   INITIIALIZING PARTICLE PROPERTIES -> DEPEND ON SOURCE CATEGORY
              */
@@ -432,7 +430,7 @@ namespace GRAL_2001
                 auszeit += idt;
                 if (auszeit >= Program.DispTimeSum)
                 {
-                    trans_conz.Conz5dZeitschleifeTransient(reflexion_flag, zcoord_nteil, AHint, mass_real, Area_cart, idt, xsi, eta, SG_nteil);
+                    TransientConcentration.Conz5dZeitschleifeTransient(reflexion_flag, zcoord_nteil, AHint, mass_real, Area_cart, idt, xsi, eta, SG_nteil);
                     goto REMOVE_PARTICLE;
                 }
 
@@ -631,13 +629,13 @@ namespace GRAL_2001
                         FFCellYPrev = FFCellY;
                         FFCellX = (int)(xsi * FFGridXRez) + 1;
                         FFCellY = (int)(eta * FFGridYRez) + 1;
+                        GrammCellX = Math.Clamp((int)(xsi1 * GrammGridXRez) + 1, 1, Program.NX);
+                        GrammCellY = Math.Clamp((int)(eta1 * GrammGridYRez) + 1, 1, Program.NY);
+
                         if ((FFCellX > Program.NII) || (FFCellY > Program.NJJ) || (FFCellX < 1) || (FFCellY < 1))
                         {
                             goto REMOVE_PARTICLE;
                         }
-
-                        GrammCellX = Math.Clamp((int)(xsi1 * GrammGridXRez) + 1, 1, Program.NX);
-                        GrammCellY = Math.Clamp((int)(eta1 * GrammGridYRez) + 1, 1, Program.NY);
                     }
                     else
                     {
@@ -823,12 +821,15 @@ namespace GRAL_2001
                                             zcoord_nteil = 2 * newTerrainHeight - zcoord_nteil;
                                         }
 
-                                        AHintold = AHint;
-                                        AHint = newTerrainHeight;
-                                        PartHeightAboveTerrain = zcoord_nteil - AHint;
                                         if (topo == Consts.TerrainAvailable)
                                         {
+                                            PartHeightAboveTerrain = zcoord_nteil - newTerrainHeight;
                                             PartHeightAboveBuilding = PartHeightAboveTerrain;
+                                        }
+                                        else
+                                        {
+                                            PartHeightAboveTerrain = zcoord_nteil;
+                                            PartHeightAboveBuilding = zcoord_nteil;
                                         }
                                     }
                                 }
@@ -914,9 +915,7 @@ namespace GRAL_2001
                     {
                         goto REMOVE_PARTICLE;
                     }
-
                     AHint = Program.AHK[FFCellX][FFCellY];
-
                     PartHeightAboveTerrain = zcoord_nteil - AHint;
                     PartHeightAboveBuilding = PartHeightAboveTerrain;
                 }
@@ -926,7 +925,7 @@ namespace GRAL_2001
                     {
                         goto REMOVE_PARTICLE;
                     }
-
+                    AHint = 0;
                     PartHeightAboveTerrain = zcoord_nteil;
                     PartHeightAboveBuilding = PartHeightAboveTerrain;
                 }


### PR DESCRIPTION
•	Fix a bug that has been causing concentrations in the building since version 23.11 for flat terrain and certain building configurations.
•	Fix a bug that leads to high initial wind speeds near the ground when transferring the GRAMM wind profile to the GRAL Grid
•	Correct the plume rise calculation, as since version 23.11 the plume rise is too high for very small point sources
•	Enable the optional usage of AVX512 processor extension for flow field calculations 
